### PR TITLE
⚡ Bolt: Optimize scalar reductions in linalg to avoid intermediate Tensor allocations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2026-01-29 - Single Pass Variance Calculation in Manifold Heap
 **Learning:** The `ChebyshevGuard::calculate` function in `ManifoldHeap` was performing two passes over the memory blocks to calculate mean and variance separately. This is a common pattern when following the mathematical definition directly. However, in a performance-critical "metabolism" loop (GC), this doubles the memory access overhead.
 **Action:** Always check for opportunities to compute statistics (mean, variance) in a single pass using Welford's algorithm or accumulated sums, especially when iterating over large data structures.
+
+## 2026-05-01 - Avoid High-Level Tensor Ops in Scalar Reductions
+**Learning:** High-level `Tensor` operations like `sub()` and `mul()` trigger intermediate heap allocations for shape and stride metadata. When computing scalar reductions (like MSE, distances, or loss functions), using these operations introduces severe memory overhead inside hot loops. Attempting to use `.min()` length truncation as a safeguard is an anti-pattern as it masks shape mismatch errors.
+**Action:** For scalar reductions, assert shape equality (`assert_eq!(a.shape, b.shape)`) and perform a single-pass iteration directly over the underlying borrowed data arrays (`a.data.borrow()`) to eliminate intermediate allocations and safely compute the result.

--- a/crates/aether-core/src/aether.rs
+++ b/crates/aether-core/src/aether.rs
@@ -304,8 +304,10 @@ impl<const D: usize> HierarchicalBlockTree<D> {
         let mut active_l1 = [false; MAX_BLOCKS];
         for (i, active) in active_l1.iter_mut().enumerate().take(self.counts[1]) {
             let parent = i / 4;
-            if parent < self.counts[2] && active_l2[parent] 
-               && !self.levels[1][i].can_prune(query, threshold) {
+            if parent < self.counts[2]
+                && active_l2[parent]
+                && !self.levels[1][i].can_prune(query, threshold)
+            {
                 *active = true;
             }
         }
@@ -313,8 +315,10 @@ impl<const D: usize> HierarchicalBlockTree<D> {
         // Level 0 (finest) - final result
         for (i, res) in result.iter_mut().enumerate().take(self.counts[0]) {
             let parent = i / 4;
-            if parent < self.counts[1] && active_l1[parent]
-               && !self.levels[0][i].can_prune(query, threshold) {
+            if parent < self.counts[1]
+                && active_l1[parent]
+                && !self.levels[0][i].can_prune(query, threshold)
+            {
                 *res = true;
             }
         }

--- a/crates/aether-core/src/lib.rs
+++ b/crates/aether-core/src/lib.rs
@@ -25,11 +25,11 @@ extern crate alloc;
 pub mod aether;
 pub mod governor;
 pub mod manifold;
-pub mod ml;
-pub mod state;
-pub mod os;
-pub mod topology;
 pub mod memory;
+pub mod ml;
+pub mod os;
+pub mod state;
+pub mod topology;
 
 // Re-export key types for convenience
 pub use aether::{BlockMetadata, DriftDetector, HierarchicalBlockTree};

--- a/crates/aether-core/src/manifold.rs
+++ b/crates/aether-core/src/manifold.rs
@@ -246,7 +246,9 @@ impl<const D: usize> SparseAttentionGraph<D> {
                 visited[current] = true;
 
                 // Add unvisited neighbors
-                for (neighbor, is_visited) in visited.iter().enumerate().take(64.min(self.point_count)) {
+                for (neighbor, is_visited) in
+                    visited.iter().enumerate().take(64.min(self.point_count))
+                {
                     if !*is_visited && self.are_neighbors(current, neighbor) && stack_top < 64 {
                         stack[stack_top] = neighbor;
                         stack_top += 1;
@@ -290,7 +292,10 @@ impl<const D: usize> SparseAttentionGraph<D> {
     ///
     /// This approximates a "local convex hull" by traversing the sparse graph (BFS)
     /// for a limited depth, effectively partitioning the manifold geodesically.
-    pub fn geodesic_partition_centroid(&self, target: ManifoldPoint<D>) -> Option<ManifoldPoint<D>> {
+    pub fn geodesic_partition_centroid(
+        &self,
+        target: ManifoldPoint<D>,
+    ) -> Option<ManifoldPoint<D>> {
         if self.point_count == 0 {
             return None;
         }
@@ -298,11 +303,11 @@ impl<const D: usize> SparseAttentionGraph<D> {
         // 1. Find the graph node closest to the target point (entry point)
         // Since `target` might be the one just added, it's likely the last one.
         // But let's be robust and check the last few points.
-        let start_node_idx = self.point_count - 1; 
+        let start_node_idx = self.point_count - 1;
 
         // 2. BFS to find the local cluster (Geodesic Neighborhood)
         // We limit depth to capture "local" structure, not the whole component
-        let max_depth = 3; 
+        let max_depth = 3;
         let mut visited = [false; MAX_POINTS];
         let mut queue = [0usize; 64];
         let mut queue_start = 0;
@@ -333,15 +338,16 @@ impl<const D: usize> SparseAttentionGraph<D> {
             // Expand neighbors if depth limit not reached
             if current_depth < max_depth {
                 // Adjacency bitmask iteration
-                let adjacency = self.adjacency[u]; 
-                // Note: Adjacency is symmetric but stored sparsely? 
-                // In our `add_point`, we set bits for i < 64. 
+                let adjacency = self.adjacency[u];
+                // Note: Adjacency is symmetric but stored sparsely?
+                // In our `add_point`, we set bits for i < 64.
                 // Let's assume simpler iteration for this limited embedded interaction.
-                // We iterate all points to check `are_neighbors` because internal representation 
+                // We iterate all points to check `are_neighbors` because internal representation
                 // in original code was slightly simplified (only stored back-edges in `adjacency`?).
                 // Let's rely on `are_neighbors` which is robust in the provided code.
-                
-                for v in 0..self.point_count.min(64) { // Limit to 64 for speed/bitmask strictness
+
+                for v in 0..self.point_count.min(64) {
+                    // Limit to 64 for speed/bitmask strictness
                     if !visited[v] && self.are_neighbors(u, v) {
                         visited[v] = true;
                         if queue_end < 64 {
@@ -352,7 +358,7 @@ impl<const D: usize> SparseAttentionGraph<D> {
                     }
                 }
             }
-            
+
             if nodes_at_current_depth == 0 {
                 current_depth += 1;
                 nodes_at_current_depth = nodes_at_next_depth;
@@ -542,7 +548,7 @@ impl<const D: usize> TopologicalPipeline<D> {
     fn map_to_tpu_id(&self, point: &ManifoldPoint<D>, projection: f64) -> u64 {
         // Synthetic Spatial Hashing (Morton-like)
         let mut hash = 0u64;
-        
+
         // Hash the input coordinates
         for i in 0..D {
             let bits = point.coords[i].to_bits();
@@ -629,17 +635,17 @@ mod tests {
     #[test]
     fn test_gatekeeper_sparsity() {
         let mut pipeline = TopologicalPipeline::<3>::new(1, 0.5);
-        
+
         // Push zero value - should be dropped by Sparsity Filter
         assert!(pipeline.push(0.0).is_none());
         assert!(pipeline.push(1e-10).is_none());
-        
+
         // Push significant value - should be processed
         // Need to fill buffer first (tau=1, D=3 -> needs 3 points)
         pipeline.push(1.0);
         pipeline.push(2.0);
         pipeline.push(3.0);
-        
+
         // Now it should return consistent output
         let result = pipeline.push(4.0);
         assert!(result.is_some());
@@ -648,28 +654,31 @@ mod tests {
     #[test]
     fn test_gatekeeper_tpu_injection() {
         let mut pipeline = TopologicalPipeline::<3>::new(1, 0.5);
-        
+
         // Fill buffer
         pipeline.push(1.0);
         pipeline.push(2.0);
         pipeline.push(3.0);
-        
+
         if let Some((_, _, tpu_id_1)) = pipeline.push(4.0) {
-             // Push same sequence again (reset logic simulated)
-             let mut pipeline2 = TopologicalPipeline::<3>::new(1, 0.5);
-             pipeline2.push(1.0);
-             pipeline2.push(2.0);
-             pipeline2.push(3.0);
-             let (_, _, tpu_id_2) = pipeline2.push(4.0).unwrap();
-             
-             assert_eq!(tpu_id_1, tpu_id_2, "TPU ID generation must be deterministic");
+            // Push same sequence again (reset logic simulated)
+            let mut pipeline2 = TopologicalPipeline::<3>::new(1, 0.5);
+            pipeline2.push(1.0);
+            pipeline2.push(2.0);
+            pipeline2.push(3.0);
+            let (_, _, tpu_id_2) = pipeline2.push(4.0).unwrap();
+
+            assert_eq!(
+                tpu_id_1, tpu_id_2,
+                "TPU ID generation must be deterministic"
+            );
         }
     }
 
     #[test]
     fn test_gatekeeper_branching() {
         let mut pipeline = TopologicalPipeline::<3>::new(1, 2.0); // large epsilon to force connection
-        
+
         // 1. Simple shape (Line) -> Betti-1 = 0
         for i in 0..10 {
             pipeline.push(i as f64);
@@ -677,7 +686,7 @@ mod tests {
         let (b0, b1, _) = pipeline.push(10.0).unwrap();
         assert_eq!(b0, 1);
         assert_eq!(b1, 0); // Linear structure has no holes
-        
+
         // 2. Complex Shape (Cycle) -> Betti-1 > 0
         pipeline.reset();
         // Create a triangle loop: (0,0,0) -> (1,0,0) -> (0.5,1,0) -> (0,0,0) around time delay
@@ -685,11 +694,14 @@ mod tests {
         // A simple sine wave often creates loops in delay embedding
         for i in 0..50 {
             let val = libm::sin(i as f64 * 0.5);
-            pipeline.push(val); 
+            pipeline.push(val);
         }
-        
+
         let (_, b1_complex, _) = pipeline.push(0.1).unwrap();
         // Sine wave in 2D/3D embedding is a loop (circle)
-        assert!(b1_complex >= 1, "Sine wave should create a cycle (Betti-1 >= 1)");
+        assert!(
+            b1_complex >= 1,
+            "Sine wave should create a cycle (Betti-1 >= 1)"
+        );
     }
 }

--- a/crates/aether-core/src/memory.rs
+++ b/crates/aether-core/src/memory.rs
@@ -15,21 +15,21 @@
 //! ═══════════════════════════════════════════════════════════════════════════════
 
 #[cfg(not(feature = "std"))]
-use alloc::vec::Vec;
-#[cfg(not(feature = "std"))]
 use alloc::boxed::Box;
-#[cfg(feature = "std")]
-use std::vec::Vec;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 #[cfg(feature = "std")]
 use std::boxed::Box;
+#[cfg(feature = "std")]
+use std::vec::Vec;
 
-use libm::{sqrt, fabs};
 use core::marker::PhantomData;
+use libm::{fabs, sqrt};
 
 /// A Geometric Cell (Gc) handle.
 /// Represents a reference to an object in the ManifoldHeap.
 /// Unlike standard pointers, this is a topological index.
-/// 
+///
 /// We implement Copy/Clone manually to avoid implicit T: Copy bound.
 #[derive(Debug, PartialOrd, Ord)]
 pub struct Gc<T> {
@@ -107,10 +107,30 @@ impl<T> Default for SpatialBlock<T> {
         Self {
             liveness: [0.0; 8],
             slots: [
-                HeapSlot::Free { next_free: usize::MAX }, HeapSlot::Free { next_free: usize::MAX },
-                HeapSlot::Free { next_free: usize::MAX }, HeapSlot::Free { next_free: usize::MAX },
-                HeapSlot::Free { next_free: usize::MAX }, HeapSlot::Free { next_free: usize::MAX },
-                HeapSlot::Free { next_free: usize::MAX }, HeapSlot::Free { next_free: usize::MAX },
+                HeapSlot::Free {
+                    next_free: usize::MAX,
+                },
+                HeapSlot::Free {
+                    next_free: usize::MAX,
+                },
+                HeapSlot::Free {
+                    next_free: usize::MAX,
+                },
+                HeapSlot::Free {
+                    next_free: usize::MAX,
+                },
+                HeapSlot::Free {
+                    next_free: usize::MAX,
+                },
+                HeapSlot::Free {
+                    next_free: usize::MAX,
+                },
+                HeapSlot::Free {
+                    next_free: usize::MAX,
+                },
+                HeapSlot::Free {
+                    next_free: usize::MAX,
+                },
             ],
             occupied_mask: 0,
         }
@@ -127,17 +147,17 @@ impl<T> SpatialBlock<T> {
 /// Aggregates statistics of its children.
 #[derive(Debug, Clone)]
 pub struct SpatialNode {
-    /// Indices of children. 
+    /// Indices of children.
     /// If `is_leaf_parent` is true, these are indices into `blocks`.
     /// Otherwise, indices into `nodes`.
     /// None indicates empty branch.
     pub children: [Option<usize>; 8],
-    
+
     /// Aggregate Mean Liveness of this branch
     pub mean_liveness: f64,
     /// Max Liveness in this branch (for quick "is hot" checks)
     pub max_liveness: f64,
-    
+
     /// Does this node point to Blocks (true) or Nodes (false)?
     pub is_leaf_parent: bool,
 }
@@ -153,7 +173,6 @@ impl SpatialNode {
     }
 }
 
-
 /// Configuration for Memory Behavior
 #[derive(Debug, Clone, Copy)]
 pub enum MemoryMode {
@@ -168,7 +187,9 @@ pub struct Config {
 
 impl Default for Config {
     fn default() -> Self {
-        Self { mode: MemoryMode::Consumer }
+        Self {
+            mode: MemoryMode::Consumer,
+        }
     }
 }
 
@@ -181,16 +202,16 @@ pub struct ManifoldHeap<T> {
     pub nodes: Vec<SpatialNode>,
     /// Root Node Index
     pub root_idx: usize,
-    
+
     /// Head of the free list (Global index)
     /// Index = block_idx * 8 + slot_idx
     free_head: Option<usize>,
-    
+
     /// Active objects count
     active_count: usize,
     /// Global entropy counter
     entropy_counter: usize,
-    
+
     pub config: Config,
 }
 
@@ -206,10 +227,10 @@ impl<T> ManifoldHeap<T> {
             config: Config::default(),
         };
         // Initialize with one root node that is a leaf parent
-        heap.nodes.push(SpatialNode::new(true)); 
+        heap.nodes.push(SpatialNode::new(true));
         heap
     }
-    
+
     /// Helper to decompose global index into (block, offset)
     fn resolve_index(index: usize) -> (usize, usize) {
         (index / 8, index % 8)
@@ -218,20 +239,20 @@ impl<T> ManifoldHeap<T> {
     /// Allocate a new object.
     pub fn alloc(&mut self, data: T) -> Gc<T> {
         self.entropy_counter += 1;
-        
+
         let (block_idx, slot_idx) = if let Some(head) = self.free_head {
             let (b, s) = Self::resolve_index(head);
             // Verify and update free_head
             if b < self.blocks.len() {
-               if let HeapSlot::Free { next_free } = &self.blocks[b].slots[s] {
-                   if *next_free == usize::MAX {
-                       self.free_head = None;
-                   } else {
-                       self.free_head = Some(*next_free);
-                   }
-               } else {
-                   panic!("Free head pointed to occupied slot");
-               }
+                if let HeapSlot::Free { next_free } = &self.blocks[b].slots[s] {
+                    if *next_free == usize::MAX {
+                        self.free_head = None;
+                    } else {
+                        self.free_head = Some(*next_free);
+                    }
+                } else {
+                    panic!("Free head pointed to occupied slot");
+                }
             }
             (b, s)
         } else {
@@ -239,19 +260,21 @@ impl<T> ManifoldHeap<T> {
             let next_blk_idx = self.blocks.len();
             self.blocks.push(SpatialBlock::new());
             self.link_block_to_tree(next_blk_idx);
-            
+
             for i in 1..7 {
-                 self.blocks[next_blk_idx].slots[i] = HeapSlot::Free { 
-                     next_free: next_blk_idx * 8 + i + 1 
-                 };
+                self.blocks[next_blk_idx].slots[i] = HeapSlot::Free {
+                    next_free: next_blk_idx * 8 + i + 1,
+                };
             }
-            self.blocks[next_blk_idx].slots[7] = HeapSlot::Free { next_free: usize::MAX };
-            
+            self.blocks[next_blk_idx].slots[7] = HeapSlot::Free {
+                next_free: usize::MAX,
+            };
+
             self.free_head = Some(next_blk_idx * 8 + 1);
             (next_blk_idx, 0)
         };
-        
-        let generation = 1; 
+
+        let generation = 1;
         self.blocks[block_idx].slots[slot_idx] = HeapSlot::Occupied {
             header: ObjectHeader {
                 marked: false,
@@ -259,20 +282,20 @@ impl<T> ManifoldHeap<T> {
             },
             data,
         };
-        self.blocks[block_idx].liveness[slot_idx] = 1.0; 
+        self.blocks[block_idx].liveness[slot_idx] = 1.0;
         self.blocks[block_idx].occupied_mask |= 1 << slot_idx;
-        
+
         self.active_count += 1;
-        
+
         Gc::new(block_idx * 8 + slot_idx, generation)
     }
-    
+
     fn link_block_to_tree(&mut self, block_idx: usize) {
         let needed_node_idx = block_idx / 8;
         if needed_node_idx >= self.nodes.len() {
-             self.nodes.push(SpatialNode::new(true));
+            self.nodes.push(SpatialNode::new(true));
         }
-        
+
         let node_idx = needed_node_idx;
         let child_slot = block_idx % 8;
         self.nodes[node_idx].children[child_slot] = Some(block_idx);
@@ -281,13 +304,17 @@ impl<T> ManifoldHeap<T> {
     /// Access mutably. Heats up object.
     pub fn get_mut(&mut self, handle: Gc<T>) -> Option<&mut T> {
         let (b, s) = Self::resolve_index(handle.index);
-        
-        if b >= self.blocks.len() { return None; }
-        
+
+        if b >= self.blocks.len() {
+            return None;
+        }
+
         let block = &mut self.blocks[b];
         match &mut block.slots[s] {
             HeapSlot::Occupied { header, data } => {
-                if header.generation != handle.generation { return None; }
+                if header.generation != handle.generation {
+                    return None;
+                }
                 // Heat up - split borrow of block works here
                 block.liveness[s] = (block.liveness[s] + 1.0).min(10.0);
                 Some(data)
@@ -295,45 +322,49 @@ impl<T> ManifoldHeap<T> {
             _ => None,
         }
     }
-    
+
     /// Access immutably (Peek). Does NOT update liveness to avoid &mut borrow.
     /// This fixes autograd multiple borrow issues.
     pub fn get(&self, handle: Gc<T>) -> Option<&T> {
         let (b, s) = Self::resolve_index(handle.index);
-        if b >= self.blocks.len() { return None; }
+        if b >= self.blocks.len() {
+            return None;
+        }
 
         match &self.blocks[b].slots[s] {
             HeapSlot::Occupied { header, data } => {
-                if header.generation != handle.generation { return None; }
+                if header.generation != handle.generation {
+                    return None;
+                }
                 Some(data)
             }
             _ => None,
         }
     }
-    
+
     pub fn touch(&mut self, handle: Gc<T>) {
         let (b, s) = Self::resolve_index(handle.index);
         if b < self.blocks.len() {
             let block = &mut self.blocks[b];
             if let HeapSlot::Occupied { header, .. } = &mut block.slots[s] {
-                 if header.generation == handle.generation {
-                     block.liveness[s] = (block.liveness[s] + 0.5).min(10.0);
-                 }
+                if header.generation == handle.generation {
+                    block.liveness[s] = (block.liveness[s] + 0.5).min(10.0);
+                }
             }
         }
     }
-    
+
     pub fn mark(&mut self, handle: Gc<T>) {
         let (b, s) = Self::resolve_index(handle.index);
-         if b < self.blocks.len() {
-             let block = &mut self.blocks[b];
-             if let HeapSlot::Occupied { header, .. } = &mut block.slots[s] {
-                 if header.generation == handle.generation {
-                     header.marked = true;
-                     block.liveness[s] = (block.liveness[s] + 2.0).min(10.0);
-                 }
-             }
-         }
+        if b < self.blocks.len() {
+            let block = &mut self.blocks[b];
+            if let HeapSlot::Occupied { header, .. } = &mut block.slots[s] {
+                if header.generation == handle.generation {
+                    header.marked = true;
+                    block.liveness[s] = (block.liveness[s] + 2.0).min(10.0);
+                }
+            }
+        }
     }
 
     pub fn active_count(&self) -> usize {
@@ -357,38 +388,46 @@ impl ChebyshevGuard {
         let mut sum = 0.0;
         let mut sum_sq = 0.0;
         let mut count = 0.0;
-        
-        for block in &heap.blocks {
-             // Optimization: skip empty blocks early
-             if block.occupied_mask == 0 { continue; }
 
-             for i in 0..8 {
-                 if (block.occupied_mask & (1 << i)) != 0 {
-                     let val = block.liveness[i];
-                     sum += val;
-                     sum_sq += val * val;
-                     count += 1.0;
-                 }
-             }
+        for block in &heap.blocks {
+            // Optimization: skip empty blocks early
+            if block.occupied_mask == 0 {
+                continue;
+            }
+
+            for i in 0..8 {
+                if (block.occupied_mask & (1 << i)) != 0 {
+                    let val = block.liveness[i];
+                    sum += val;
+                    sum_sq += val * val;
+                    count += 1.0;
+                }
+            }
         }
-        
-       if count == 0.0 {
-            return Self { mean: 0.0, std_dev: 0.0, k: 2.0 };
+
+        if count == 0.0 {
+            return Self {
+                mean: 0.0,
+                std_dev: 0.0,
+                k: 2.0,
+            };
         }
 
         let mean = sum / count;
         let variance = (sum_sq / count) - (mean * mean);
         let variance = if variance < 0.0 { 0.0 } else { variance };
-        
+
         Self {
             mean,
             std_dev: sqrt(variance),
             k: 2.0,
         }
     }
-    
+
     pub fn is_safe(&self, liveness: f64) -> bool {
-        if liveness >= self.mean { return true; }
+        if liveness >= self.mean {
+            return true;
+        }
         let boundary = self.mean - (self.k * self.std_dev);
         liveness > boundary
     }
@@ -396,8 +435,9 @@ impl ChebyshevGuard {
 
 impl<T> ManifoldHeap<T> {
     /// Regulation with Spatial Optimization
-    pub fn regulate_entropy<F>(&mut self, tracer: F) -> usize 
-    where F: Fn(&mut Self) 
+    pub fn regulate_entropy<F>(&mut self, tracer: F) -> usize
+    where
+        F: Fn(&mut Self),
     {
         // 0. Reset Marks
         for block in &mut self.blocks {
@@ -407,58 +447,64 @@ impl<T> ManifoldHeap<T> {
                 }
             }
         }
-        
+
         // 1. Trace
         tracer(self);
-        
+
         // 2. Calc Stats
         let guard = ChebyshevGuard::calculate(self);
-        
+
         let mut pruned = 0;
         let num_blocks = self.blocks.len();
         let mut new_free_head = self.free_head;
-        
+
         for b_idx in 0..num_blocks {
             let block = &mut self.blocks[b_idx];
-            
+
             for s_idx in 0..8 {
-                 if (block.occupied_mask & (1 << s_idx)) == 0 { continue; }
-                 
-                 block.liveness[s_idx] *= 0.95;
-                 
-                 let should_prune;
-                 
-                 if let HeapSlot::Occupied { header, .. } = &mut block.slots[s_idx] {
-                     let is_marked = header.marked;
-                     let is_safe = guard.is_safe(block.liveness[s_idx]);
-                     
-                     if is_marked {
-                         block.liveness[s_idx] += 0.1;
-                         should_prune = false;
-                     } else if is_safe {
-                         should_prune = false;
-                     } else {
-                         should_prune = true;
-                     }
-                 } else {
-                     should_prune = false;
-                 }
-                 
-                 if should_prune {
-                      block.occupied_mask &= !(1 << s_idx);
-                      let next = if let Some(h) = new_free_head { h } else { usize::MAX };
-                      block.slots[s_idx] = HeapSlot::Free { next_free: next };
-                      new_free_head = Some(b_idx * 8 + s_idx);
-                      
-                      pruned += 1;
-                 }
+                if (block.occupied_mask & (1 << s_idx)) == 0 {
+                    continue;
+                }
+
+                block.liveness[s_idx] *= 0.95;
+
+                let should_prune;
+
+                if let HeapSlot::Occupied { header, .. } = &mut block.slots[s_idx] {
+                    let is_marked = header.marked;
+                    let is_safe = guard.is_safe(block.liveness[s_idx]);
+
+                    if is_marked {
+                        block.liveness[s_idx] += 0.1;
+                        should_prune = false;
+                    } else if is_safe {
+                        should_prune = false;
+                    } else {
+                        should_prune = true;
+                    }
+                } else {
+                    should_prune = false;
+                }
+
+                if should_prune {
+                    block.occupied_mask &= !(1 << s_idx);
+                    let next = if let Some(h) = new_free_head {
+                        h
+                    } else {
+                        usize::MAX
+                    };
+                    block.slots[s_idx] = HeapSlot::Free { next_free: next };
+                    new_free_head = Some(b_idx * 8 + s_idx);
+
+                    pruned += 1;
+                }
             }
         }
-        
+
         self.active_count -= pruned;
         self.free_head = new_free_head;
         self.entropy_counter = 0;
-        
+
         pruned
     }
 }
@@ -472,12 +518,12 @@ mod tests {
         let mut heap = ManifoldHeap::<i32>::new();
         let a = heap.alloc(10);
         let b = heap.alloc(20);
-        
+
         assert_eq!(*heap.get(a).unwrap(), 10);
         assert_eq!(*heap.get(b).unwrap(), 20);
         assert_eq!(heap.active_count(), 2);
     }
-    
+
     #[test]
     fn test_spatial_clustering() {
         let mut heap = ManifoldHeap::<i32>::new();
@@ -485,17 +531,16 @@ mod tests {
         for i in 0..8 {
             handles.push(heap.alloc(i));
         }
-        
+
         let h9 = heap.alloc(99);
         let (b1, _) = ManifoldHeap::<i32>::resolve_index(h9.index);
         assert_eq!(b1, 1);
         assert_eq!(heap.blocks.len(), 2);
     }
-    
+
     #[test]
     fn test_simd_alignment() {
         use core::mem::align_of;
         assert_eq!(align_of::<SpatialBlock<i32>>(), 64);
     }
-
 }

--- a/crates/aether-core/src/ml/autograd.rs
+++ b/crates/aether-core/src/ml/autograd.rs
@@ -4,7 +4,7 @@
 //!
 //! "History is not a tree, it is a tape."
 //!
-//! A Wengert List (Tape-based) implementation of reverse-mode automatic 
+//! A Wengert List (Tape-based) implementation of reverse-mode automatic
 //! differentiation. It records operations on `Gc<Tensor>` handles, allowing
 //! the graph to be stored efficiently in the Manifold Heap.
 //!
@@ -26,14 +26,26 @@ use crate::ml::tensor::Tensor;
 #[derive(Debug, Clone, Copy)]
 pub enum Op {
     /// out = lhs + rhs
-    Add { out: Gc<Tensor>, lhs: Gc<Tensor>, rhs: Gc<Tensor> },
-    
+    Add {
+        out: Gc<Tensor>,
+        lhs: Gc<Tensor>,
+        rhs: Gc<Tensor>,
+    },
+
     /// out = lhs * rhs (element-wise)
-    Mul { out: Gc<Tensor>, lhs: Gc<Tensor>, rhs: Gc<Tensor> },
-    
+    Mul {
+        out: Gc<Tensor>,
+        lhs: Gc<Tensor>,
+        rhs: Gc<Tensor>,
+    },
+
     /// out = lhs @ rhs (matrix multiplication)
-    MatMul { out: Gc<Tensor>, lhs: Gc<Tensor>, rhs: Gc<Tensor> },
-    
+    MatMul {
+        out: Gc<Tensor>,
+        lhs: Gc<Tensor>,
+        rhs: Gc<Tensor>,
+    },
+
     /// out = max(0, input)
     ReLU { out: Gc<Tensor>, input: Gc<Tensor> },
 }
@@ -107,13 +119,13 @@ impl<'a> Context<'a> {
         let b = self.heap.get(rhs.data).expect("Stale handle RHS");
         let result = a.add(b);
         let out = self.heap.alloc(result);
-        
-        self.tape.push(Op::Add { 
-            out, 
-            lhs: lhs.data, 
-            rhs: rhs.data 
+
+        self.tape.push(Op::Add {
+            out,
+            lhs: lhs.data,
+            rhs: rhs.data,
         });
-        
+
         Variable::new(out)
     }
 
@@ -123,13 +135,13 @@ impl<'a> Context<'a> {
         let b = self.heap.get(rhs.data).expect("Stale handle RHS");
         let result = a.mul(b);
         let out = self.heap.alloc(result);
-        
-        self.tape.push(Op::Mul { 
-            out, 
-            lhs: lhs.data, 
-            rhs: rhs.data 
+
+        self.tape.push(Op::Mul {
+            out,
+            lhs: lhs.data,
+            rhs: rhs.data,
         });
-        
+
         Variable::new(out)
     }
 
@@ -139,13 +151,13 @@ impl<'a> Context<'a> {
         let b = self.heap.get(rhs.data).expect("Stale handle RHS");
         let result = a.matmul(b);
         let out = self.heap.alloc(result);
-        
-        self.tape.push(Op::MatMul { 
-            out, 
-            lhs: lhs.data, 
-            rhs: rhs.data 
+
+        self.tape.push(Op::MatMul {
+            out,
+            lhs: lhs.data,
+            rhs: rhs.data,
         });
-        
+
         Variable::new(out)
     }
 
@@ -154,12 +166,12 @@ impl<'a> Context<'a> {
         let val = self.heap.get(input.data).expect("Stale handle");
         let result = val.map(|x| if x > 0.0 { x } else { 0.0 });
         let out = self.heap.alloc(result);
-        
-        self.tape.push(Op::ReLU { 
-            out, 
-            input: input.data 
+
+        self.tape.push(Op::ReLU {
+            out,
+            input: input.data,
         });
-        
+
         Variable::new(out)
     }
 
@@ -171,7 +183,7 @@ impl<'a> Context<'a> {
         let mut grads: Vec<Option<Tensor>> = alloc::vec![None; max_idx];
         #[cfg(feature = "std")]
         let mut grads: Vec<Option<Tensor>> = std::vec![None; max_idx];
-        
+
         // Seed output gradient
         let target_tensor = self.heap.get(target.data).expect("Target lost");
         grads[target.data.index] = Some(Tensor::ones(&target_tensor.shape));
@@ -180,45 +192,45 @@ impl<'a> Context<'a> {
         for op in self.tape.ops.iter().rev() {
             match op {
                 Op::Add { out, lhs, rhs } => {
-                     // Solves borrow checker by cloning Option first
-                     let grad_out = grads[out.index].clone();
-                     if let Some(grad) = grad_out {
-                         // dL/d(lhs) += dL/dout * 1
-                         Self::accumulate_grad(&mut grads, lhs.index, &grad);
-                         Self::accumulate_grad(&mut grads, rhs.index, &grad);
-                     }
-                },
+                    // Solves borrow checker by cloning Option first
+                    let grad_out = grads[out.index].clone();
+                    if let Some(grad) = grad_out {
+                        // dL/d(lhs) += dL/dout * 1
+                        Self::accumulate_grad(&mut grads, lhs.index, &grad);
+                        Self::accumulate_grad(&mut grads, rhs.index, &grad);
+                    }
+                }
                 Op::Mul { out, lhs, rhs } => {
                     let grad_out = grads[out.index].clone();
                     if let Some(grad) = grad_out {
                         let lhs_val = self.heap.get(*lhs).unwrap();
                         let rhs_val = self.heap.get(*rhs).unwrap();
-                        
+
                         // dL/dLhs = grad_out * rhs
                         let d_lhs: Tensor = grad.mul(rhs_val);
                         Self::accumulate_grad(&mut grads, lhs.index, &d_lhs);
-                        
+
                         // dL/dRhs = grad_out * lhs
                         let d_rhs: Tensor = grad.mul(lhs_val);
                         Self::accumulate_grad(&mut grads, rhs.index, &d_rhs);
                     }
-                },
+                }
                 Op::MatMul { out, lhs, rhs } => {
-                     let grad_out = grads[out.index].clone();
-                     if let Some(grad) = grad_out {
+                    let grad_out = grads[out.index].clone();
+                    if let Some(grad) = grad_out {
                         let lhs_val = self.heap.get(*lhs).unwrap();
                         let rhs_val = self.heap.get(*rhs).unwrap();
-                        
+
                         // C = A @ B
                         // dA = dC @ B^T
                         let d_lhs: Tensor = grad.matmul(&rhs_val.transpose());
                         Self::accumulate_grad(&mut grads, lhs.index, &d_lhs);
-                        
+
                         // dB = A^T @ dC
                         let d_rhs: Tensor = lhs_val.transpose().matmul(&grad);
                         Self::accumulate_grad(&mut grads, rhs.index, &d_rhs);
-                     }
-                },
+                    }
+                }
                 Op::ReLU { out, input } => {
                     let grad_out = grads[out.index].clone();
                     if let Some(grad) = grad_out {
@@ -231,15 +243,15 @@ impl<'a> Context<'a> {
                 }
             }
         }
-        
+
         grads
     }
-    
+
     fn accumulate_grad(grads: &mut Vec<Option<Tensor>>, idx: usize, grad: &Tensor) {
         if idx >= grads.len() {
             grads.resize(idx + 1 + 256, None);
         }
-        
+
         match &mut grads[idx] {
             Some(existing) => {
                 let new = existing.add(grad);
@@ -302,39 +314,39 @@ mod tests {
 
         // Input: [1.0, 1.0] (1x2)
         let x = ctx.var(Tensor::new(&[1.0, 1.0], &[1, 2]));
-        
+
         // W1: Identity [[1, 0], [0, 1]] (2x2)
         let w1 = ctx.var(Tensor::new(&[1.0, 0.0, 0.0, 1.0], &[2, 2]));
-        
+
         // W2: [[1], [-2]] (2x1)
         let w2 = ctx.var(Tensor::new(&[1.0, -2.0], &[2, 1]));
 
         // Forward
         // z1 = x @ W1 = [1, 1]
         let z1 = ctx.matmul(x, w1);
-        
+
         // h1 = relu(z1) = [1, 1]
         let h1 = ctx.relu(z1);
-        
+
         // y = h1 @ W2 = 1*1 + 1*-2 = -1 (1x1)
         let y = ctx.matmul(h1, w2);
-        
+
         // Loss = (y - target)^2, target=0
         // Loss = y * y
         let loss = ctx.mul(y, y);
-        
+
         // Backward
         // dLoss/dy = 2y = -2
         let grads = ctx.backward(loss);
-        
+
         // Checks
         let dy = grads[y.data.index].as_ref().unwrap();
         // Manually: dL/dy = 2*(-1) = -2
-        assert!((dy.get(&[0,0]) - (-2.0)).abs() < 1e-6);
-        
+        assert!((dy.get(&[0, 0]) - (-2.0)).abs() < 1e-6);
+
         let dw2 = grads[w2.data.index].as_ref().unwrap();
         // dL/dW2 = h1.T @ dy = [[1], [1]] @ [-2] = [[-2], [-2]]
-        assert!((dw2.get(&[0,0]) - (-2.0)).abs() < 1e-6);
-        assert!((dw2.get(&[1,0]) - (-2.0)).abs() < 1e-6);
+        assert!((dw2.get(&[0, 0]) - (-2.0)).abs() < 1e-6);
+        assert!((dw2.get(&[1, 0]) - (-2.0)).abs() < 1e-6);
     }
 }

--- a/crates/aether-core/src/ml/convolution.rs
+++ b/crates/aether-core/src/ml/convolution.rs
@@ -8,8 +8,8 @@
 
 #![allow(dead_code)]
 
-use libm::sqrt;
 use crate::ml::neural::Activation;
+use libm::sqrt;
 
 /// Maximum kernel size (e.g., 3x3, 5x5)
 const MAX_KERNEL_SIZE: usize = 5;
@@ -39,7 +39,7 @@ pub struct Conv2D {
     pub padding: usize,
     /// Activation
     pub activation: Activation,
-    
+
     // Cache for backprop
     pub last_input: [[[[f64; MAX_IMG_DIM]; MAX_IMG_DIM]; MAX_CHANNELS_IN]; 1], // Batch size 1 for now
     pub last_output_dim: (usize, usize),
@@ -60,8 +60,9 @@ impl Conv2D {
 
         // Kaiming/He initialization
         let scale = sqrt(2.0 / (in_c * k_size * k_size) as f64);
-        
-        let mut weights = [[[[0.0; MAX_KERNEL_SIZE]; MAX_KERNEL_SIZE]; MAX_CHANNELS_IN]; MAX_CHANNELS_OUT];
+
+        let mut weights =
+            [[[[0.0; MAX_KERNEL_SIZE]; MAX_KERNEL_SIZE]; MAX_CHANNELS_IN]; MAX_CHANNELS_OUT];
         let mut rng = 42u64;
 
         for channel_out in weights.iter_mut().take(out_c) {
@@ -93,11 +94,15 @@ impl Conv2D {
     /// Forward pass
     /// input: [channels][height][width]
     pub fn forward(
-        &mut self, 
+        &mut self,
         input: &[[[f64; MAX_IMG_DIM]; MAX_IMG_DIM]; MAX_CHANNELS_IN],
         input_h: usize,
-        input_w: usize
-    ) -> ([[[f64; MAX_IMG_DIM]; MAX_IMG_DIM]; MAX_CHANNELS_OUT], usize, usize) {
+        input_w: usize,
+    ) -> (
+        [[[f64; MAX_IMG_DIM]; MAX_IMG_DIM]; MAX_CHANNELS_OUT],
+        usize,
+        usize,
+    ) {
         // Cache input
         self.last_input[0] = *input;
 
@@ -111,7 +116,7 @@ impl Conv2D {
             for (y, row_out) in channel_out.iter_mut().enumerate().take(output_h) {
                 for (x, val_out) in row_out.iter_mut().enumerate().take(output_w) {
                     let mut sum = self.biases[o];
-                    
+
                     // Convolve
                     let in_y_origin = (y * self.stride) as isize - self.padding as isize;
                     let in_x_origin = (x * self.stride) as isize - self.padding as isize;
@@ -122,10 +127,13 @@ impl Conv2D {
                                 let in_y = in_y_origin + ky as isize;
                                 let in_x = in_x_origin + kx as isize;
 
-                                if in_y >= 0 && in_y < input_h as isize && 
-                                   in_x >= 0 && in_x < input_w as isize {
-                                    sum += input_channel[in_y as usize][in_x as usize] * 
-                                           self.weights[o][c][ky][kx];
+                                if in_y >= 0
+                                    && in_y < input_h as isize
+                                    && in_x >= 0
+                                    && in_x < input_w as isize
+                                {
+                                    sum += input_channel[in_y as usize][in_x as usize]
+                                        * self.weights[o][c][ky][kx];
                                 }
                             }
                         }
@@ -149,7 +157,7 @@ mod tests {
     fn test_conv2d_initialization() {
         let conv = Conv2D::new(1, 1, 3, 1, 1, Activation::ReLU);
         assert_eq!(conv.weights.len(), MAX_CHANNELS_OUT); // Array size fixed
-        // Check params
+                                                          // Check params
         assert_eq!(conv.kernel_size, 3);
         assert_eq!(conv.stride, 1);
         assert_eq!(conv.padding, 1);
@@ -159,11 +167,11 @@ mod tests {
     fn test_conv2d_forward_shape() {
         let mut conv = Conv2D::new(1, 1, 3, 1, 1, Activation::ReLU);
         let input = [[[0.5; MAX_IMG_DIM]; MAX_IMG_DIM]; MAX_CHANNELS_IN];
-        
+
         // 10x10 input
         // Output size: (10 + 2*1 - 3) / 1 + 1 = 10
         let (_, h, w) = conv.forward(&input, 10, 10);
-        
+
         assert_eq!(h, 10);
         assert_eq!(w, 10);
     }

--- a/crates/aether-core/src/ml/gossip.rs
+++ b/crates/aether-core/src/ml/gossip.rs
@@ -18,11 +18,11 @@
 
 #![allow(dead_code)]
 
-use libm::sqrt;
-use crate::ml::clustering::{KMeans, KMeansResult}; // Reuse existing clustering logic if needed
+use crate::ml::clustering::{KMeans, KMeansResult};
+use libm::sqrt; // Reuse existing clustering logic if needed
 
 /// Maximum dimension for the manifold points
-const MAX_DIM: usize = 3; 
+const MAX_DIM: usize = 3;
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // Core Structures
@@ -33,7 +33,7 @@ const MAX_DIM: usize = 3;
 pub struct GossipNode {
     /// Unique ID of the core
     pub id: usize,
-    
+
     /// Local data shard (simulated)
     local_data: heapless::Vec<[f64; MAX_DIM], 256>,
 
@@ -85,20 +85,21 @@ impl GossipNode {
         }
 
         // Initially, global estimate is just the local centroid
-        if self.weight <= 1.0 { 
-             self.global_estimate = self.local_centroid;
+        if self.weight <= 1.0 {
+            self.global_estimate = self.local_centroid;
         }
     }
 
     /// Receive a gossip message (neighbor's estimate) and update local state
     /// Uses exponential moving average or weighted average for consensus.
-    /// 
+    ///
     /// Formula: NewEstimate = (OldEstimate * Weight + NeighborEstimate) / (Weight + 1)
     pub fn update_consensus(&mut self, neighbor_estimate: [f64; MAX_DIM]) {
         let alpha = 0.5; // Mixing rate. 0.5 means equal weight to self and neighbor (fast mixing)
 
         for i in 0..MAX_DIM {
-            self.global_estimate[i] = (self.global_estimate[i] * (1.0 - alpha)) + (neighbor_estimate[i] * alpha);
+            self.global_estimate[i] =
+                (self.global_estimate[i] * (1.0 - alpha)) + (neighbor_estimate[i] * alpha);
         }
     }
 }
@@ -217,10 +218,10 @@ mod tests {
         ring.add_node(n1);
 
         // Expected global average: [5, 5, 0]
-        
+
         // Run gossip
         let iters = ring.converge(0.1, 100);
-        
+
         println!("Converged in {} iterations", iters);
 
         // Verify

--- a/crates/aether-core/src/ml/linalg.rs
+++ b/crates/aether-core/src/ml/linalg.rs
@@ -14,9 +14,8 @@ use alloc::vec;
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
 
-
 #[cfg(not(feature = "std"))]
-use libm::{log, exp}; // Keep only what's not redefined locally or needed
+use libm::{exp, log}; // Keep only what's not redefined locally or needed
 #[cfg(feature = "std")]
 use std::f64;
 
@@ -56,7 +55,15 @@ impl LossConfig {
             LossConfig::MAE => {
                 let diff = y_pred.sub(y_true);
                 let n = y_true.shape.iter().product::<usize>() as f64;
-                diff.map(|x| if x > 0.0 { 1.0 / n } else if x < 0.0 { -1.0 / n } else { 0.0 })
+                diff.map(|x| {
+                    if x > 0.0 {
+                        1.0 / n
+                    } else if x < 0.0 {
+                        -1.0 / n
+                    } else {
+                        0.0
+                    }
+                })
             }
             LossConfig::BinaryCrossEntropy => {
                 // dL/dp = (1-y)/(1-p) - y/p
@@ -64,11 +71,11 @@ impl LossConfig {
                 let pred_data = y_pred.data.borrow();
                 let n = true_data.len();
                 let mut grad_data = Vec::with_capacity(n); // Fixed: using Vec instead of let mut
-                
+
                 for i in 0..n {
                     let y = true_data[i];
                     let p = pred_data[i].clamp(1e-7, 1.0 - 1e-7); // Avoid div by zero
-                    
+
                     let grad = -(y / p) + ((1.0 - y) / (1.0 - p));
                     grad_data.push(grad / n as f64);
                 }
@@ -85,7 +92,7 @@ impl LossConfig {
                 for i in 0..n {
                     let y = true_data[i];
                     let p = pred_data[i];
-                    
+
                     if 1.0 - y * p > 0.0 {
                         grad_data.push(-y / n as f64);
                     } else {
@@ -100,17 +107,27 @@ impl LossConfig {
 
 /// Mean Squared Error
 pub fn mse(y_true: &Tensor, y_pred: &Tensor) -> f64 {
-    let diff = y_true.sub(y_pred);
-    diff.mul(&diff).sum() / y_true.shape.iter().product::<usize>() as f64
+    assert_eq!(y_true.shape, y_pred.shape);
+    let mut sum = 0.0;
+    let true_data = y_true.data.borrow();
+    let pred_data = y_pred.data.borrow();
+    let n = true_data.len();
+
+    for i in 0..n {
+        let diff = true_data[i] - pred_data[i];
+        sum += diff * diff;
+    }
+    sum / n as f64
 }
 
 /// Mean Absolute Error
 pub fn mae(y_true: &Tensor, y_pred: &Tensor) -> f64 {
+    assert_eq!(y_true.shape, y_pred.shape);
     let mut sum = 0.0;
     let true_data = y_true.data.borrow();
     let pred_data = y_pred.data.borrow();
-    let n = true_data.len().min(pred_data.len());
-    
+    let n = true_data.len();
+
     for i in 0..n {
         sum += fabs(true_data[i] - pred_data[i]);
     }
@@ -124,22 +141,23 @@ pub fn rmse(y_true: &Tensor, y_pred: &Tensor) -> f64 {
 
 /// Binary Cross-Entropy
 pub fn binary_cross_entropy(y_true: &Tensor, y_pred: &Tensor) -> f64 {
+    assert_eq!(y_true.shape, y_pred.shape);
     let mut sum = 0.0;
     let true_data = y_true.data.borrow();
     let pred_data = y_pred.data.borrow();
-    let n = true_data.len().min(pred_data.len());
-    
+    let n = true_data.len();
+
     for i in 0..n {
         let p = pred_data[i].clamp(1e-7, 1.0 - 1e-7);
         let y = true_data[i];
-        
+
         #[cfg(not(feature = "std"))]
         {
-             sum -= y * log(p) + (1.0 - y) * log(1.0 - p);
+            sum -= y * log(p) + (1.0 - y) * log(1.0 - p);
         }
         #[cfg(feature = "std")]
         {
-             sum -= y * p.ln() + (1.0 - y) * (1.0 - p).ln();
+            sum -= y * p.ln() + (1.0 - y) * (1.0 - p).ln();
         }
     }
     sum / n as f64
@@ -147,11 +165,12 @@ pub fn binary_cross_entropy(y_true: &Tensor, y_pred: &Tensor) -> f64 {
 
 /// Hinge Loss (for SVM)
 pub fn hinge_loss(y_true: &Tensor, y_pred: &Tensor) -> f64 {
+    assert_eq!(y_true.shape, y_pred.shape);
     let mut sum = 0.0;
     let true_data = y_true.data.borrow();
     let pred_data = y_pred.data.borrow();
-    let n = true_data.len().min(pred_data.len());
-    
+    let n = true_data.len();
+
     for i in 0..n {
         let margin = 1.0 - true_data[i] * pred_data[i];
         if margin > 0.0 {
@@ -173,9 +192,9 @@ where
     // Clone structure
     let grad = Tensor::zeros(&x.shape);
     let n = x.shape.iter().product();
-    
+
     let mut grad_data = grad.data.borrow_mut();
-    
+
     // We need a deep copy to mutate independent probe.
     let mut x_plus = Tensor::new(&x.data.borrow(), &x.shape);
     let mut x_minus = Tensor::new(&x.data.borrow(), &x.shape);
@@ -183,21 +202,21 @@ where
     {
         let mut xp_data = x_plus.data.borrow_mut();
         let mut xm_data = x_minus.data.borrow_mut();
-        
+
         drop(xp_data);
         drop(xm_data);
-        
+
         for i in 0..n {
-             let original = x.data.borrow()[i];
-             
-             x_plus.data.borrow_mut()[i] = original + epsilon;
-             x_minus.data.borrow_mut()[i] = original - epsilon;
-             
-             grad_data[i] = (f(&x_plus) - f(&x_minus)) / (2.0 * epsilon);
-             
-             // Restore
-             x_plus.data.borrow_mut()[i] = original;
-             x_minus.data.borrow_mut()[i] = original;
+            let original = x.data.borrow()[i];
+
+            x_plus.data.borrow_mut()[i] = original + epsilon;
+            x_minus.data.borrow_mut()[i] = original - epsilon;
+
+            grad_data[i] = (f(&x_plus) - f(&x_minus)) / (2.0 * epsilon);
+
+            // Restore
+            x_plus.data.borrow_mut()[i] = original;
+            x_minus.data.borrow_mut()[i] = original;
         }
     }
 
@@ -211,29 +230,40 @@ where
 
 /// Euclidean distance
 pub fn euclidean_distance(a: &Tensor, b: &Tensor) -> f64 {
-    let diff = a.sub(b);
-    sqrt(diff.mul(&diff).sum())
+    assert_eq!(a.shape, b.shape);
+    let mut sum = 0.0;
+    let a_data = a.data.borrow();
+    let b_data = b.data.borrow();
+
+    for i in 0..a_data.len() {
+        let diff = a_data[i] - b_data[i];
+        sum += diff * diff;
+    }
+    sqrt(sum)
 }
 
 /// Manhattan distance (L1)
 pub fn manhattan_distance(a: &Tensor, b: &Tensor) -> f64 {
+    assert_eq!(a.shape, b.shape);
     let mut sum = 0.0;
-    // Tensor doesn't have L1 norm built-in, do manual
-    let diff_data = a.sub(b).data;
-    let data = diff_data.borrow();
-    for &val in data.iter() {
-        sum += fabs(val);
+    let a_data = a.data.borrow();
+    let b_data = b.data.borrow();
+
+    for i in 0..a_data.len() {
+        sum += fabs(a_data[i] - b_data[i]);
     }
     sum
 }
 
 /// Chebyshev distance (L∞)
 pub fn chebyshev_distance(a: &Tensor, b: &Tensor) -> f64 {
-    let diff = a.sub(b);
-    let data = diff.data.borrow();
+    assert_eq!(a.shape, b.shape);
     let mut max = 0.0;
-    for &val in data.iter() {
-        let abs_val = fabs(val);
+    let a_data = a.data.borrow();
+    let b_data = b.data.borrow();
+
+    for i in 0..a_data.len() {
+        let abs_val = fabs(a_data[i] - b_data[i]);
         if abs_val > max {
             max = abs_val;
         }
@@ -243,9 +273,16 @@ pub fn chebyshev_distance(a: &Tensor, b: &Tensor) -> f64 {
 
 /// RBF kernel value
 pub fn rbf_kernel(a: &Tensor, b: &Tensor, gamma: f64) -> f64 {
-    let dist = a.sub(b);
-    let dist_sq = dist.mul(&dist).sum();
-    exp(-gamma * dist_sq)
+    assert_eq!(a.shape, b.shape);
+    let mut sum = 0.0;
+    let a_data = a.data.borrow();
+    let b_data = b.data.borrow();
+
+    for i in 0..a_data.len() {
+        let diff = a_data[i] - b_data[i];
+        sum += diff * diff;
+    }
+    exp(-gamma * sum)
 }
 
 fn fabs(x: f64) -> f64 {

--- a/crates/aether-core/src/ml/mod.rs
+++ b/crates/aether-core/src/ml/mod.rs
@@ -20,13 +20,13 @@
 #![allow(dead_code)]
 
 // Core modules
+pub mod autograd;
 pub mod benchmark;
 pub mod convergence;
-pub mod linalg;
 pub mod convolution;
+pub mod linalg;
 pub mod regressor;
 pub mod tensor;
-pub mod autograd;
 
 // Extended ML library
 pub mod classification;
@@ -43,7 +43,7 @@ pub use clustering::{
 };
 pub use convergence::*;
 // pub use linalg::{Matrix, Vector}; // Removed
-pub use tensor::Tensor;
-pub use neural::{Activation, DenseLayer, TrainingResult, MLP, OptimizerConfig};
+pub use neural::{Activation, DenseLayer, OptimizerConfig, TrainingResult, MLP};
 pub use regressor::*;
+pub use tensor::Tensor;
 pub mod gossip;

--- a/crates/aether-core/src/ml/neural.rs
+++ b/crates/aether-core/src/ml/neural.rs
@@ -10,19 +10,19 @@
 #![allow(dead_code)]
 
 #[cfg(feature = "alloc")]
+use alloc::boxed::Box;
+#[cfg(feature = "alloc")]
 use alloc::vec;
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
-#[cfg(feature = "alloc")]
-use alloc::boxed::Box;
 
 #[cfg(not(feature = "std"))]
-use libm::{fabs}; // Adjust based on usage
+use libm::fabs; // Adjust based on usage
 #[cfg(feature = "std")]
 use std::f64;
 
-use super::tensor::Tensor;
 use super::linalg::LossConfig;
+use super::tensor::Tensor;
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // Activation Functions
@@ -47,12 +47,15 @@ impl Activation {
                 let data_borrow = x.data.borrow();
                 let max_val = data_borrow.iter().fold(f64::NEG_INFINITY, |a, &b| a.max(b));
                 let mut sum = 0.0;
-                let data: Vec<f64> = data_borrow.iter().map(|&v| {
-                    let e = exp(v - max_val);
-                    sum += e;
-                    e
-                }).collect();
-                
+                let data: Vec<f64> = data_borrow
+                    .iter()
+                    .map(|&v| {
+                        let e = exp(v - max_val);
+                        sum += e;
+                        e
+                    })
+                    .collect();
+
                 let normalized: Vec<f64> = data.iter().map(|&v| v / sum.max(1e-10)).collect();
                 Tensor::new(&normalized, &x.shape)
             }
@@ -63,7 +66,13 @@ impl Activation {
     /// Apply to single value
     pub fn apply_scalar(&self, x: f64) -> f64 {
         match self {
-            Activation::ReLU => if x > 0.0 { x } else { 0.0 },
+            Activation::ReLU => {
+                if x > 0.0 {
+                    x
+                } else {
+                    0.0
+                }
+            }
             Activation::Sigmoid => 1.0 / (1.0 + exp(-x.clamp(-500.0, 500.0))),
             Activation::Tanh => {
                 let e_pos = exp(x.clamp(-500.0, 500.0));
@@ -71,7 +80,13 @@ impl Activation {
                 (e_pos - e_neg) / (e_pos + e_neg)
             }
             Activation::Linear => x,
-            Activation::LeakyReLU => if x > 0.0 { x } else { 0.01 * x },
+            Activation::LeakyReLU => {
+                if x > 0.0 {
+                    x
+                } else {
+                    0.01 * x
+                }
+            }
             Activation::Softmax => x, // Should not be called on scalar
         }
     }
@@ -86,7 +101,13 @@ impl Activation {
 
     fn derivative_scalar(&self, x: f64) -> f64 {
         match self {
-            Activation::ReLU => if x > 0.0 { 1.0 } else { 0.0 },
+            Activation::ReLU => {
+                if x > 0.0 {
+                    1.0
+                } else {
+                    0.0
+                }
+            }
             Activation::Sigmoid => {
                 let s = self.apply_scalar(x);
                 s * (1.0 - s)
@@ -96,8 +117,14 @@ impl Activation {
                 1.0 - t * t
             }
             Activation::Linear => 1.0,
-            Activation::LeakyReLU => if x > 0.0 { 1.0 } else { 0.01 },
-             Activation::Softmax => 1.0, 
+            Activation::LeakyReLU => {
+                if x > 0.0 {
+                    1.0
+                } else {
+                    0.01
+                }
+            }
+            Activation::Softmax => 1.0,
         }
     }
 }
@@ -108,8 +135,16 @@ impl Activation {
 
 #[derive(Debug, Clone)]
 pub enum OptimizerConfig {
-    SGD { learning_rate: f64, momentum: f64 },
-    Adam { learning_rate: f64, beta1: f64, beta2: f64, epsilon: f64 },
+    SGD {
+        learning_rate: f64,
+        momentum: f64,
+    },
+    Adam {
+        learning_rate: f64,
+        beta1: f64,
+        beta2: f64,
+        epsilon: f64,
+    },
 }
 
 #[derive(Debug, Clone)]
@@ -140,20 +175,25 @@ pub struct DenseLayer {
     pub input_size: usize,
     pub output_size: usize,
     pub activation: Activation,
-    
+
     // Cache for backprop
     last_input: Option<Tensor>,
     last_z: Option<Tensor>,
-    
+
     // Optimizer State
     opt_state: OptimizerState,
 }
 
 impl DenseLayer {
-    pub fn new(input_size: usize, output_size: usize, activation: Activation, seed: Option<u64>) -> Self {
+    pub fn new(
+        input_size: usize,
+        output_size: usize,
+        activation: Activation,
+        seed: Option<u64>,
+    ) -> Self {
         // Xavier initialization
         let scale = sqrt(2.0 / (input_size + output_size) as f64);
-        
+
         let mut rng = seed.unwrap_or(42);
         let mut w_data = Vec::with_capacity(input_size * output_size);
         for _ in 0..(input_size * output_size) {
@@ -161,7 +201,7 @@ impl DenseLayer {
             let r = (rng as f64 / u64::MAX as f64) * 2.0 - 1.0;
             w_data.push(r * scale);
         }
-        
+
         let weights = Tensor::new(&w_data, &[output_size, input_size]);
         let biases = Tensor::zeros(&[output_size, 1]);
 
@@ -176,7 +216,7 @@ impl DenseLayer {
             opt_state: OptimizerState::None,
         }
     }
-    
+
     pub fn init_optimizer(&mut self, config: &OptimizerConfig) {
         match config {
             OptimizerConfig::SGD { .. } => {
@@ -200,33 +240,41 @@ impl DenseLayer {
     /// Forward pass
     pub fn forward(&mut self, input: &Tensor) -> Tensor {
         self.last_input = Some(input.clone());
-        
+
         // z = W * x + b
         // weights: [out, in], input: [in] -> [out]
-        
+
         let wx = self.weights.matmul(input);
         let z = wx.add(&self.biases);
-        
+
         self.last_z = Some(z.clone());
         self.activation.apply(&z)
     }
 
     /// Backward pass
     pub fn backward(&mut self, grad_output: &Tensor, config: &OptimizerConfig) -> Tensor {
-        let last_z = self.last_z.as_ref().expect("Forward must be called before backward").clone();
-        let last_input = self.last_input.as_ref().expect("Forward must be called before backward").clone();
-        
+        let last_z = self
+            .last_z
+            .as_ref()
+            .expect("Forward must be called before backward")
+            .clone();
+        let last_input = self
+            .last_input
+            .as_ref()
+            .expect("Forward must be called before backward")
+            .clone();
+
         let act_deriv = self.activation.derivative(&last_z);
         let delta = grad_output.mul(&act_deriv);
-        
+
         // Gradients
         // dW = delta * input^T
         // delta: [out], input: [in]
-        
+
         let mut dw_data = Vec::with_capacity(self.output_size * self.input_size);
         let delta_data = delta.data.borrow();
         let input_data = last_input.data.borrow();
-        
+
         for i in 0..self.output_size {
             for j in 0..self.input_size {
                 dw_data.push(delta_data[i] * input_data[j]);
@@ -234,51 +282,82 @@ impl DenseLayer {
         }
         let grad_w = Tensor::new(&dw_data, &self.weights.shape);
         let grad_b = delta.clone();
-        
+
         // Compute input gradient for next layer
         // dx = W^T * delta
         let w_t = self.weights.transpose();
         let grad_input = w_t.matmul(&delta);
-        
+
         self.update_weights(&grad_w, &grad_b, config);
-        
+
         grad_input
     }
-    
+
     fn update_weights(&mut self, grad_w: &Tensor, grad_b: &Tensor, config: &OptimizerConfig) {
         match config {
-            OptimizerConfig::SGD { learning_rate, momentum } => {
-                if let OptimizerState::SGD { velocity_w, velocity_b } = &mut self.opt_state {
-                    *velocity_w = velocity_w.scale(*momentum).sub(&grad_w.scale(*learning_rate));
-                    *velocity_b = velocity_b.scale(*momentum).sub(&grad_b.scale(*learning_rate));
-                    
+            OptimizerConfig::SGD {
+                learning_rate,
+                momentum,
+            } => {
+                if let OptimizerState::SGD {
+                    velocity_w,
+                    velocity_b,
+                } = &mut self.opt_state
+                {
+                    *velocity_w = velocity_w
+                        .scale(*momentum)
+                        .sub(&grad_w.scale(*learning_rate));
+                    *velocity_b = velocity_b
+                        .scale(*momentum)
+                        .sub(&grad_b.scale(*learning_rate));
+
                     self.weights = self.weights.add(velocity_w);
                     self.biases = self.biases.add(velocity_b);
                 }
             }
-            OptimizerConfig::Adam { learning_rate, beta1, beta2, epsilon } => {
-                if let OptimizerState::Adam { m_w, v_w, m_b, v_b, t } = &mut self.opt_state {
+            OptimizerConfig::Adam {
+                learning_rate,
+                beta1,
+                beta2,
+                epsilon,
+            } => {
+                if let OptimizerState::Adam {
+                    m_w,
+                    v_w,
+                    m_b,
+                    v_b,
+                    t,
+                } = &mut self.opt_state
+                {
                     *t += 1;
                     let t_val = *t as f64;
-                    
+
                     // Weights
                     *m_w = m_w.scale(*beta1).add(&grad_w.scale(1.0 - beta1));
-                    *v_w = v_w.scale(*beta2).add(&grad_w.mul(grad_w).scale(1.0 - beta2));
-                    
+                    *v_w = v_w
+                        .scale(*beta2)
+                        .add(&grad_w.mul(grad_w).scale(1.0 - beta2));
+
                     let m_hat_w = m_w.scale(1.0 / (1.0 - pow(*beta1, t_val)));
                     let v_hat_w = v_w.scale(1.0 / (1.0 - pow(*beta2, t_val)));
-                    
-                    let update_w = m_hat_w.mul(&v_hat_w.map(|x| 1.0 / (sqrt(x) + epsilon))).scale(*learning_rate);
+
+                    let update_w = m_hat_w
+                        .mul(&v_hat_w.map(|x| 1.0 / (sqrt(x) + epsilon)))
+                        .scale(*learning_rate);
                     self.weights = self.weights.sub(&update_w);
 
                     // Biases
                     *m_b = m_b.scale(*beta1).add(&grad_b.scale(1.0 - beta1));
-                    *v_b = v_b.scale(*beta2).add(&grad_b.mul(grad_b).scale(1.0 - beta2));
-                    
+                    *v_b = v_b
+                        .scale(*beta2)
+                        .add(&grad_b.mul(grad_b).scale(1.0 - beta2));
+
                     let m_hat_b = m_b.scale(1.0 / (1.0 - pow(*beta1, t_val)));
                     let v_hat_b = v_b.scale(1.0 / (1.0 - pow(*beta2, t_val)));
-                    
-                    let update_b = m_hat_b.mul(&v_hat_b.map(|x| 1.0 / (sqrt(x) + epsilon))).scale(*learning_rate);
+
+                    let update_b = m_hat_b
+                        .mul(&v_hat_b.map(|x| 1.0 / (sqrt(x) + epsilon)))
+                        .scale(*learning_rate);
                     self.biases = self.biases.sub(&update_b);
                 }
             }
@@ -308,7 +387,13 @@ impl MLP {
     }
 
     /// Add a dense layer
-    pub fn add_layer(&mut self, input_size: usize, output_size: usize, activation: Activation, seed: Option<u64>) {
+    pub fn add_layer(
+        &mut self,
+        input_size: usize,
+        output_size: usize,
+        activation: Activation,
+        seed: Option<u64>,
+    ) {
         let mut layer = DenseLayer::new(input_size, output_size, activation, seed);
         layer.init_optimizer(&self.config);
         self.layers.push(layer);
@@ -322,7 +407,7 @@ impl MLP {
         }
         current
     }
-    
+
     /// Predict (Forward without mutating state if possible? No, dense layer caches input)
     pub fn predict(&mut self, input: &Tensor) -> Tensor {
         self.forward(input)
@@ -332,42 +417,42 @@ impl MLP {
     pub fn train_step(&mut self, input: &Tensor, target: &Tensor) -> f64 {
         // Forward
         let output = self.forward(input);
-        
+
         // Loss
         let loss = self.loss.compute(target, &output);
-        
+
         // Initial gradient
         let grad = self.loss.derivative(target, &output);
-        
+
         // Backward
         let mut current_grad = grad;
         for layer in self.layers.iter_mut().rev() {
             current_grad = layer.backward(&current_grad, &self.config);
         }
-        
+
         loss
     }
-    
+
     pub fn fit(&mut self, x: &[Tensor], y: &[Tensor], epochs: usize) -> TrainingResult {
-         let mut result = TrainingResult::default();
-         let n_samples = x.len();
-         
-         for epoch in 0..epochs {
-             let mut total_loss = 0.0;
-             for i in 0..n_samples {
-                 total_loss += self.train_step(&x[i], &y[i]);
-             }
-             let avg_loss = total_loss / n_samples as f64;
-             
-             if epoch < 100 {
-                 result.loss_history.push(avg_loss);
-             }
-             result.final_loss = avg_loss;
-         }
-         
-         result.epochs = epochs as u32;
-         result.converged = true; // Simple logic
-         result
+        let mut result = TrainingResult::default();
+        let n_samples = x.len();
+
+        for epoch in 0..epochs {
+            let mut total_loss = 0.0;
+            for i in 0..n_samples {
+                total_loss += self.train_step(&x[i], &y[i]);
+            }
+            let avg_loss = total_loss / n_samples as f64;
+
+            if epoch < 100 {
+                result.loss_history.push(avg_loss);
+            }
+            result.final_loss = avg_loss;
+        }
+
+        result.epochs = epochs as u32;
+        result.converged = true; // Simple logic
+        result
     }
 }
 
@@ -416,16 +501,19 @@ fn exp(x: f64) -> f64 {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use super::OptimizerConfig;
+    use super::*;
 
     #[test]
     fn test_mlp_xor() {
-        let config = OptimizerConfig::SGD { learning_rate: 0.1, momentum: 0.9 };
+        let config = OptimizerConfig::SGD {
+            learning_rate: 0.1,
+            momentum: 0.9,
+        };
         let mut mlp = MLP::new(config, LossConfig::MSE);
         mlp.add_layer(2, 8, Activation::Tanh, Some(42));
         mlp.add_layer(8, 1, Activation::Sigmoid, Some(43));
-        
+
         // XOR Data
         let x = vec![
             Tensor::new(&[0.0, 0.0], &[2, 1]),
@@ -439,28 +527,33 @@ mod tests {
             Tensor::new(&[1.0], &[1, 1]),
             Tensor::new(&[0.0], &[1, 1]),
         ];
-        
-        let result = mlp.fit(&x, &y, 500); 
+
+        let result = mlp.fit(&x, &y, 500);
         println!("Final XOR Loss: {}", result.final_loss);
         assert!(result.converged);
-        // assert!(result.final_loss < 0.1); 
+        // assert!(result.final_loss < 0.1);
         // XOR sometimes fails with simple random init seed, but logic runs.
     }
-    
+
     #[test]
     fn test_mlp_large_scale() {
         // Fix 3.1: Verify we can have > 64 neurons
-        let config = OptimizerConfig::Adam { learning_rate: 0.01, beta1: 0.9, beta2: 0.999, epsilon: 1e-8 };
+        let config = OptimizerConfig::Adam {
+            learning_rate: 0.01,
+            beta1: 0.9,
+            beta2: 0.999,
+            epsilon: 1e-8,
+        };
         let mut mlp = MLP::new(config, LossConfig::BinaryCrossEntropy);
-        
+
         // Input 100 -> Hidden 128 -> Output 10
         mlp.add_layer(100, 128, Activation::ReLU, Some(1));
         mlp.add_layer(128, 10, Activation::Softmax, Some(2));
-        
+
         let input = Tensor::new(&vec![0.5; 100], &[100, 1]);
         let output = mlp.forward(&input);
-        
+
         assert_eq!(output.shape, vec![10, 1]);
-        assert!((output.sum() - 1.0).abs() < 1e-5); 
+        assert!((output.sum() - 1.0).abs() < 1e-5);
     }
 }

--- a/crates/aether-core/src/ml/tensor.rs
+++ b/crates/aether-core/src/ml/tensor.rs
@@ -10,15 +10,15 @@
 #[cfg(feature = "alloc")]
 use alloc::rc::Rc;
 #[cfg(feature = "alloc")]
-use alloc::vec::Vec;
-#[cfg(feature = "alloc")]
 use alloc::vec;
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
 #[cfg(not(feature = "alloc"))]
 use std::rc::Rc;
 #[cfg(not(feature = "alloc"))]
-use std::vec::Vec;
-#[cfg(not(feature = "alloc"))]
 use std::vec;
+#[cfg(not(feature = "alloc"))]
+use std::vec::Vec;
 
 use core::cell::RefCell;
 use libm::{exp, sqrt};
@@ -38,7 +38,11 @@ impl Tensor {
     /// Create a new tensor from a raw vector (consuming it) and shape
     pub fn from_vec(data: Vec<f64>, shape: Vec<usize>) -> Self {
         let total_size: usize = shape.iter().product();
-        assert_eq!(data.len(), total_size, "Data length must match shape product");
+        assert_eq!(
+            data.len(),
+            total_size,
+            "Data length must match shape product"
+        );
 
         let mut strides = vec![0; shape.len()];
         let mut stride = 1;
@@ -57,7 +61,11 @@ impl Tensor {
     /// Create a new tensor from a slice and shape
     pub fn new(data: &[f64], shape: &[usize]) -> Self {
         let total_size: usize = shape.iter().product();
-        assert_eq!(data.len(), total_size, "Data length must match shape product");
+        assert_eq!(
+            data.len(),
+            total_size,
+            "Data length must match shape product"
+        );
 
         let mut strides = vec![0; shape.len()];
         let mut stride = 1;
@@ -92,11 +100,11 @@ impl Tensor {
         let total_size: usize = shape.iter().product();
         let fan_in = if shape.len() > 1 { shape[1] } else { 1 };
         let bound = sqrt(3.0 / fan_in as f64);
-        
+
         // Simple LCG for deterministic randomness in no_std
         let mut rng = 42u64;
         let mut data: Vec<f64> = Vec::with_capacity(total_size);
-        
+
         for _ in 0..total_size {
             rng = rng.wrapping_mul(6364136223846793005).wrapping_add(1);
             let r = (rng as f64 / u64::MAX as f64) * 2.0 - 1.0;
@@ -133,9 +141,9 @@ impl Tensor {
         let total_size: usize = self.shape.iter().product();
         let mut new_data = Vec::with_capacity(total_size);
         let data = self.data.borrow();
-        
+
         new_data.extend_from_slice(&*data);
-        
+
         Self {
             data: Rc::new(RefCell::new(new_data)),
             shape: vec![total_size],
@@ -147,7 +155,10 @@ impl Tensor {
     pub fn matmul(&self, other: &Tensor) -> Tensor {
         assert_eq!(self.shape.len(), 2, "Matmul requires 2D tensors");
         assert_eq!(other.shape.len(), 2, "Matmul requires 2D tensors");
-        assert_eq!(self.shape[1], other.shape[0], "Dimension mismatch for matmul");
+        assert_eq!(
+            self.shape[1], other.shape[0],
+            "Dimension mismatch for matmul"
+        );
 
         let m = self.shape[0];
         let k = self.shape[1];
@@ -169,7 +180,7 @@ impl Tensor {
                 data_c[i * result.strides[0] + j * result.strides[1]] = sum;
             }
         }
-        
+
         drop(data_c);
         result
     }
@@ -179,7 +190,7 @@ impl Tensor {
         assert_eq!(self.shape, other.shape, "Shape mismatch for add");
         let total_size: usize = self.shape.iter().product();
         let mut result_data = Vec::with_capacity(total_size);
-        
+
         let data_a = self.data.borrow();
         let data_b = other.data.borrow();
 
@@ -195,7 +206,7 @@ impl Tensor {
         assert_eq!(self.shape, other.shape, "Shape mismatch for mul");
         let total_size: usize = self.shape.iter().product();
         let mut result_data = Vec::with_capacity(total_size);
-        
+
         let data_a = self.data.borrow();
         let data_b = other.data.borrow();
 
@@ -224,18 +235,18 @@ impl Tensor {
         assert_eq!(self.shape.len(), 2, "Transpose support 2D only for now");
         let rows = self.shape[0];
         let cols = self.shape[1];
-        
+
         let mut result = Tensor::zeros(&[cols, rows]);
         let data = self.data.borrow();
         let mut res_data = result.data.borrow_mut();
 
         for i in 0..rows {
             for j in 0..cols {
-                res_data[j * result.strides[0] + i * result.strides[1]] = 
+                res_data[j * result.strides[0] + i * result.strides[1]] =
                     data[i * self.strides[0] + j * self.strides[1]];
             }
         }
-        
+
         drop(res_data);
         result
     }
@@ -250,7 +261,7 @@ impl Tensor {
         assert_eq!(self.shape, other.shape, "Shape mismatch for sub");
         let total_size: usize = self.shape.iter().product();
         let mut result_data = Vec::with_capacity(total_size);
-        
+
         let data_a = self.data.borrow();
         let data_b = other.data.borrow();
 
@@ -262,16 +273,18 @@ impl Tensor {
     }
 
     /// Element-wise mapping
-    pub fn map<F>(&self, f: F) -> Self 
-    where F: Fn(f64) -> f64 {
+    pub fn map<F>(&self, f: F) -> Self
+    where
+        F: Fn(f64) -> f64,
+    {
         let total_size: usize = self.shape.iter().product();
         let mut result_data = Vec::with_capacity(total_size);
         let data = self.data.borrow();
-        
+
         for i in 0..total_size {
             result_data.push(f(data[i]));
         }
-        
+
         Self::new(&result_data, &self.shape)
     }
 }

--- a/crates/aether-core/src/os.rs
+++ b/crates/aether-core/src/os.rs
@@ -52,9 +52,26 @@ impl CpuContext {
     /// Create a new, blank CPU context
     pub const fn empty() -> Self {
         Self {
-            r15: 0, r14: 0, r13: 0, r12: 0, r11: 0, r10: 0, r9: 0, r8: 0,
-            rbp: 0, rdi: 0, rsi: 0, rdx: 0, rcx: 0, rbx: 0, rax: 0,
-            rip: 0, cs: 0, rflags: 0, rsp: 0, ss: 0,
+            r15: 0,
+            r14: 0,
+            r13: 0,
+            r12: 0,
+            r11: 0,
+            r10: 0,
+            r9: 0,
+            r8: 0,
+            rbp: 0,
+            rdi: 0,
+            rsi: 0,
+            rdx: 0,
+            rcx: 0,
+            rbx: 0,
+            rax: 0,
+            rip: 0,
+            cs: 0,
+            rflags: 0,
+            rsp: 0,
+            ss: 0,
         }
     }
 }
@@ -120,11 +137,11 @@ impl PageTableEntry {
     pub fn addr(&self) -> u64 {
         self.entry & 0x000F_FFFF_FFFF_F000
     }
-    
+
     /// Set the physical address
     pub fn set_addr(&mut self, addr: u64) {
-         let flags = self.entry & !0x000F_FFFF_FFFF_F000;
-         self.entry = (addr & 0x000F_FFFF_FFFF_F000) | flags;
+        let flags = self.entry & !0x000F_FFFF_FFFF_F000;
+        self.entry = (addr & 0x000F_FFFF_FFFF_F000) | flags;
     }
 }
 
@@ -189,19 +206,19 @@ pub struct MemoryRegion {
 pub struct HardwareTopology {
     /// Number of physical CPU cores (Neural Clusters)
     pub cpu_cores: usize,
-    
+
     /// Number of NUMA nodes (Memory Locality Domains)
     pub numa_nodes: usize,
-    
+
     /// Total usable system memory in bytes
     pub total_memory: u64,
-    
+
     /// Physical address of the root configuration (RSDP for ACPI, DTB for ARM)
     pub config_root: PhysAddr,
-    
+
     /// List of memory regions (The "Territory")
     pub memory_map: [MemoryRegion; 32], // Fixed size for no_std bootstrap
-    
+
     /// Number of valid regions in the map
     pub memory_map_len: usize,
 }
@@ -228,7 +245,7 @@ impl HardwareTopology {
         if self.memory_map_len < 32 {
             self.memory_map[self.memory_map_len] = region;
             self.memory_map_len += 1;
-            
+
             if region.region_type == MemoryType::Usable {
                 self.total_memory += region.length;
             }
@@ -262,10 +279,10 @@ pub enum KernelMode {
 pub trait BiosInterface {
     /// Get the raw memory map from firmware
     fn memory_map(&self) -> &[MemoryRegion];
-    
+
     /// Get the framebuffer info (if graphics enabled)
     fn framebuffer(&self) -> Option<FrameBufferInfo>;
-    
+
     /// Get the ACPI/DTB root pointer
     fn config_root(&self) -> PhysAddr;
 }
@@ -278,4 +295,3 @@ pub struct FrameBufferInfo {
     pub stride: u32,
     pub bytes_per_pixel: u8,
 }
-

--- a/crates/aether-core/src/state.rs
+++ b/crates/aether-core/src/state.rs
@@ -135,7 +135,10 @@ impl<const D: usize> Sub for SystemState<D> {
 
     fn sub(self, other: Self) -> [f64; D] {
         let mut result = [0.0; D];
-        for (r, (a, b)) in result.iter_mut().zip(self.vector.iter().zip(other.vector.iter())) {
+        for (r, (a, b)) in result
+            .iter_mut()
+            .zip(self.vector.iter().zip(other.vector.iter()))
+        {
             *r = a - b;
         }
         result


### PR DESCRIPTION
💡 **What:** Refactored scalar reduction functions (`mse`, `mae`, `binary_cross_entropy`, `hinge_loss`, `euclidean_distance`, `manhattan_distance`, `chebyshev_distance`, and `rbf_kernel`) in `crates/aether-core/src/ml/linalg.rs` to iterate over raw borrowed slice data directly instead of using high-level `Tensor::sub` or `Tensor::mul` methods. Also replaced `.min()` truncation with exact `assert_eq!(a.shape, b.shape)` checks.

🎯 **Why:** High-level `Tensor` operations allocate new `Rc<RefCell<Vec<f64>>>` instances along with cloned `shape` and `stride` metadata. In hot ML mathematical loops doing scalar reductions, these intermediate heap allocations create severe memory pressure and GC overhead. Additionally, the `.min()` truncation approach for disparate shapes masked errors instead of rejecting them.

📊 **Impact:** Eliminates O(N) intermediate Tensor allocations during training loops and distance calculation phases.

🔬 **Measurement:** Code changes verified directly via inspection and test suite execution (`cargo clippy` and `cargo test`), which ensures calculations remain mathematically identical. Added corresponding journal entry.

---
*PR created automatically by Jules for task [5124804379038153332](https://jules.google.com/task/5124804379038153332) started by @teerthsharma*