### PR TITLE
⚡ Bolt: Avoid redundant O(N) slice allocations during tensor operations

### DIFF
--- a/crates/aether-core/src/ml/tensor.rs
+++ b/crates/aether-core/src/ml/tensor.rs
@@ -92,14 +92,14 @@ impl Tensor {
     pub fn zeros(shape: &[usize]) -> Self {
         let total_size: usize = shape.iter().product();
         let data = vec![0.0; total_size];
-        Self::new(&data, shape)
+        Self::from_vec(data, shape.to_vec())
     }
 
     /// Create a tensor filled with ones
     pub fn ones(shape: &[usize]) -> Self {
         let total_size: usize = shape.iter().product();
         let data = vec![1.0; total_size];
-        Self::new(&data, shape)
+        Self::from_vec(data, shape.to_vec())
     }
 
     /// Create a tensor with Xavier initialization
@@ -118,7 +118,7 @@ impl Tensor {
             data.push(r * bound);
         }
 
-        Self::new(&data, shape)
+        Self::from_vec(data, shape.to_vec())
     }
 
     /// Get value at index (handles strides)
@@ -201,13 +201,14 @@ impl Tensor {
 
         // ⚡ Bolt: Iterators with .zip().map().collect() elide manual bounds checks
         // and allow LLVM to auto-vectorize more effectively than indexed for loops.
+        // Using from_vec avoids redundant O(N) slice allocations.
         let result_data: Vec<f64> = data_a
             .iter()
             .zip(data_b.iter())
             .map(|(a, b)| a + b)
             .collect();
 
-        Self::new(&result_data, &self.shape)
+        Self::from_vec(result_data, self.shape.clone())
     }
 
     /// Element-wise multiplication
@@ -219,26 +220,26 @@ impl Tensor {
 
         // ⚡ Bolt: Iterators with .zip().map().collect() elide manual bounds checks
         // and allow LLVM to auto-vectorize more effectively than indexed for loops.
+        // Using from_vec avoids redundant O(N) slice allocations.
         let result_data: Vec<f64> = data_a
             .iter()
             .zip(data_b.iter())
             .map(|(a, b)| a * b)
             .collect();
 
-        Self::new(&result_data, &self.shape)
+        Self::from_vec(result_data, self.shape.clone())
     }
 
     /// Scalar multiplication
     pub fn scale(&self, s: f64) -> Tensor {
-        let total_size: usize = self.shape.iter().product();
-        let mut result_data = Vec::with_capacity(total_size);
         let data = self.data.borrow();
 
-        for i in 0..total_size {
-            result_data.push(data[i] * s);
-        }
+        // ⚡ Bolt: Iterators with .map().collect() elide manual bounds checks
+        // and allow LLVM to auto-vectorize more effectively than indexed for loops.
+        // Using from_vec avoids redundant O(N) slice allocations.
+        let result_data: Vec<f64> = data.iter().map(|&x| x * s).collect();
 
-        Self::new(&result_data, &self.shape)
+        Self::from_vec(result_data, self.shape.clone())
     }
 
     /// Transpose (2D)
@@ -276,13 +277,14 @@ impl Tensor {
 
         // ⚡ Bolt: Iterators with .zip().map().collect() elide manual bounds checks
         // and allow LLVM to auto-vectorize more effectively than indexed for loops.
+        // Using from_vec avoids redundant O(N) slice allocations.
         let result_data: Vec<f64> = data_a
             .iter()
             .zip(data_b.iter())
             .map(|(a, b)| a - b)
             .collect();
 
-        Self::new(&result_data, &self.shape)
+        Self::from_vec(result_data, self.shape.clone())
     }
 
     /// Element-wise mapping
@@ -290,14 +292,13 @@ impl Tensor {
     where
         F: Fn(f64) -> f64,
     {
-        let total_size: usize = self.shape.iter().product();
-        let mut result_data = Vec::with_capacity(total_size);
         let data = self.data.borrow();
 
-        for i in 0..total_size {
-            result_data.push(f(data[i]));
-        }
+        // ⚡ Bolt: Iterators with .map().collect() elide manual bounds checks
+        // and allow LLVM to auto-vectorize more effectively than indexed for loops.
+        // Using from_vec avoids redundant O(N) slice allocations.
+        let result_data: Vec<f64> = data.iter().map(|&x| f(x)).collect();
 
-        Self::new(&result_data, &self.shape)
+        Self::from_vec(result_data, self.shape.clone())
     }
 }

--- a/patch.diff
+++ b/patch.diff
@@ -1,0 +1,236 @@
+<<<<<<< SEARCH
+    /// Create a tensor filled with zeros
+    pub fn zeros(shape: &[usize]) -> Self {
+        let total_size: usize = shape.iter().product();
+        let data = vec![0.0; total_size];
+        Self::new(&data, shape)
+    }
+
+    /// Create a tensor filled with ones
+    pub fn ones(shape: &[usize]) -> Self {
+        let total_size: usize = shape.iter().product();
+        let data = vec![1.0; total_size];
+        Self::new(&data, shape)
+    }
+
+    /// Create a tensor with Xavier initialization
+    pub fn kaiming_uniform(shape: &[usize]) -> Self {
+        let total_size: usize = shape.iter().product();
+        let fan_in = if shape.len() > 1 { shape[1] } else { 1 };
+        let bound = sqrt(3.0 / fan_in as f64);
+
+        // Simple LCG for deterministic randomness in no_std
+        let mut rng = 42u64;
+        let mut data: Vec<f64> = Vec::with_capacity(total_size);
+
+        for _ in 0..total_size {
+            rng = rng.wrapping_mul(6364136223846793005).wrapping_add(1);
+            let r = (rng as f64 / u64::MAX as f64) * 2.0 - 1.0;
+            data.push(r * bound);
+        }
+
+        Self::new(&data, shape)
+    }
+=======
+    /// Create a tensor filled with zeros
+    pub fn zeros(shape: &[usize]) -> Self {
+        let total_size: usize = shape.iter().product();
+        let data = vec![0.0; total_size];
+        Self::from_vec(data, shape.to_vec())
+    }
+
+    /// Create a tensor filled with ones
+    pub fn ones(shape: &[usize]) -> Self {
+        let total_size: usize = shape.iter().product();
+        let data = vec![1.0; total_size];
+        Self::from_vec(data, shape.to_vec())
+    }
+
+    /// Create a tensor with Xavier initialization
+    pub fn kaiming_uniform(shape: &[usize]) -> Self {
+        let total_size: usize = shape.iter().product();
+        let fan_in = if shape.len() > 1 { shape[1] } else { 1 };
+        let bound = sqrt(3.0 / fan_in as f64);
+
+        // Simple LCG for deterministic randomness in no_std
+        let mut rng = 42u64;
+        let mut data: Vec<f64> = Vec::with_capacity(total_size);
+
+        for _ in 0..total_size {
+            rng = rng.wrapping_mul(6364136223846793005).wrapping_add(1);
+            let r = (rng as f64 / u64::MAX as f64) * 2.0 - 1.0;
+            data.push(r * bound);
+        }
+
+        Self::from_vec(data, shape.to_vec())
+    }
+>>>>>>> REPLACE
+<<<<<<< SEARCH
+    /// Element-wise addition
+    pub fn add(&self, other: &Tensor) -> Tensor {
+        assert_eq!(self.shape, other.shape, "Shape mismatch for add");
+
+        let data_a = self.data.borrow();
+        let data_b = other.data.borrow();
+
+        // ⚡ Bolt: Iterators with .zip().map().collect() elide manual bounds checks
+        // and allow LLVM to auto-vectorize more effectively than indexed for loops.
+        let result_data: Vec<f64> = data_a
+            .iter()
+            .zip(data_b.iter())
+            .map(|(a, b)| a + b)
+            .collect();
+
+        Self::new(&result_data, &self.shape)
+    }
+
+    /// Element-wise multiplication
+    pub fn mul(&self, other: &Tensor) -> Tensor {
+        assert_eq!(self.shape, other.shape, "Shape mismatch for mul");
+
+        let data_a = self.data.borrow();
+        let data_b = other.data.borrow();
+
+        // ⚡ Bolt: Iterators with .zip().map().collect() elide manual bounds checks
+        // and allow LLVM to auto-vectorize more effectively than indexed for loops.
+        let result_data: Vec<f64> = data_a
+            .iter()
+            .zip(data_b.iter())
+            .map(|(a, b)| a * b)
+            .collect();
+
+        Self::new(&result_data, &self.shape)
+    }
+
+    /// Scalar multiplication
+    pub fn scale(&self, s: f64) -> Tensor {
+        let total_size: usize = self.shape.iter().product();
+        let mut result_data = Vec::with_capacity(total_size);
+        let data = self.data.borrow();
+
+        for i in 0..total_size {
+            result_data.push(data[i] * s);
+        }
+
+        Self::new(&result_data, &self.shape)
+    }
+=======
+    /// Element-wise addition
+    pub fn add(&self, other: &Tensor) -> Tensor {
+        assert_eq!(self.shape, other.shape, "Shape mismatch for add");
+
+        let data_a = self.data.borrow();
+        let data_b = other.data.borrow();
+
+        // ⚡ Bolt: Iterators with .zip().map().collect() elide manual bounds checks
+        // and allow LLVM to auto-vectorize more effectively than indexed for loops.
+        // Using from_vec avoids redundant O(N) slice allocations.
+        let result_data: Vec<f64> = data_a
+            .iter()
+            .zip(data_b.iter())
+            .map(|(a, b)| a + b)
+            .collect();
+
+        Self::from_vec(result_data, self.shape.clone())
+    }
+
+    /// Element-wise multiplication
+    pub fn mul(&self, other: &Tensor) -> Tensor {
+        assert_eq!(self.shape, other.shape, "Shape mismatch for mul");
+
+        let data_a = self.data.borrow();
+        let data_b = other.data.borrow();
+
+        // ⚡ Bolt: Iterators with .zip().map().collect() elide manual bounds checks
+        // and allow LLVM to auto-vectorize more effectively than indexed for loops.
+        // Using from_vec avoids redundant O(N) slice allocations.
+        let result_data: Vec<f64> = data_a
+            .iter()
+            .zip(data_b.iter())
+            .map(|(a, b)| a * b)
+            .collect();
+
+        Self::from_vec(result_data, self.shape.clone())
+    }
+
+    /// Scalar multiplication
+    pub fn scale(&self, s: f64) -> Tensor {
+        let data = self.data.borrow();
+
+        // ⚡ Bolt: Iterators with .map().collect() elide manual bounds checks
+        // and allow LLVM to auto-vectorize more effectively than indexed for loops.
+        // Using from_vec avoids redundant O(N) slice allocations.
+        let result_data: Vec<f64> = data.iter().map(|&x| x * s).collect();
+
+        Self::from_vec(result_data, self.shape.clone())
+    }
+>>>>>>> REPLACE
+<<<<<<< SEARCH
+    /// Element-wise subtraction
+    pub fn sub(&self, other: &Tensor) -> Tensor {
+        assert_eq!(self.shape, other.shape, "Shape mismatch for sub");
+
+        let data_a = self.data.borrow();
+        let data_b = other.data.borrow();
+
+        // ⚡ Bolt: Iterators with .zip().map().collect() elide manual bounds checks
+        // and allow LLVM to auto-vectorize more effectively than indexed for loops.
+        let result_data: Vec<f64> = data_a
+            .iter()
+            .zip(data_b.iter())
+            .map(|(a, b)| a - b)
+            .collect();
+
+        Self::new(&result_data, &self.shape)
+    }
+
+    /// Element-wise mapping
+    pub fn map<F>(&self, f: F) -> Self
+    where
+        F: Fn(f64) -> f64,
+    {
+        let total_size: usize = self.shape.iter().product();
+        let mut result_data = Vec::with_capacity(total_size);
+        let data = self.data.borrow();
+
+        for i in 0..total_size {
+            result_data.push(f(data[i]));
+        }
+
+        Self::new(&result_data, &self.shape)
+    }
+=======
+    /// Element-wise subtraction
+    pub fn sub(&self, other: &Tensor) -> Tensor {
+        assert_eq!(self.shape, other.shape, "Shape mismatch for sub");
+
+        let data_a = self.data.borrow();
+        let data_b = other.data.borrow();
+
+        // ⚡ Bolt: Iterators with .zip().map().collect() elide manual bounds checks
+        // and allow LLVM to auto-vectorize more effectively than indexed for loops.
+        // Using from_vec avoids redundant O(N) slice allocations.
+        let result_data: Vec<f64> = data_a
+            .iter()
+            .zip(data_b.iter())
+            .map(|(a, b)| a - b)
+            .collect();
+
+        Self::from_vec(result_data, self.shape.clone())
+    }
+
+    /// Element-wise mapping
+    pub fn map<F>(&self, f: F) -> Self
+    where
+        F: Fn(f64) -> f64,
+    {
+        let data = self.data.borrow();
+
+        // ⚡ Bolt: Iterators with .map().collect() elide manual bounds checks
+        // and allow LLVM to auto-vectorize more effectively than indexed for loops.
+        // Using from_vec avoids redundant O(N) slice allocations.
+        let result_data: Vec<f64> = data.iter().map(|&x| f(x)).collect();
+
+        Self::from_vec(result_data, self.shape.clone())
+    }
+>>>>>>> REPLACE


### PR DESCRIPTION
**💡 What:**
Replaced `Self::new(&data, shape)` with `Self::from_vec(data, shape.to_vec())` or `Self::from_vec(result_data, self.shape.clone())` in `zeros`, `ones`, `kaiming_uniform`, `add`, `mul`, `scale`, `sub`, and `map` functions in `aether-core::ml::tensor`.

**🎯 Why:**
When computing element-wise operations, using `.iter().zip().map().collect()` efficiently elides bounds checks and vectorizes operations, but wrapping the collected `Vec` with `Self::new()` triggered redundant O(N) allocations via `to_vec()` and internal copies.

**📊 Impact:**
Avoids O(N) slice allocations for many tensor operations, which can yield a significant speedup for large tensors and operations happening repeatedly in hot paths.

**🔬 Measurement:**
Tested via running the test suite. Profile it locally to observe reduction in allocations and heap allocations per iteration.

---
*PR created automatically by Jules for task [9979785301071988236](https://jules.google.com/task/9979785301071988236) started by @teerthsharma*