### PR TITLE
⚡ Bolt: Avoid redundant O(N) slice allocations during tensor arithmetic and initialization

### DIFF
--- a/crates/aether-core/src/ml/tensor.rs
+++ b/crates/aether-core/src/ml/tensor.rs
@@ -92,14 +92,14 @@ impl Tensor {
     pub fn zeros(shape: &[usize]) -> Self {
         let total_size: usize = shape.iter().product();
         let data = vec![0.0; total_size];
-        Self::new(&data, shape)
+        Self::from_vec(data, shape.to_vec())
     }
 
     /// Create a tensor filled with ones
     pub fn ones(shape: &[usize]) -> Self {
         let total_size: usize = shape.iter().product();
         let data = vec![1.0; total_size];
-        Self::new(&data, shape)
+        Self::from_vec(data, shape.to_vec())
     }
 
     /// Create a tensor with Xavier initialization
@@ -118,7 +118,7 @@ impl Tensor {
             data.push(r * bound);
         }
 
-        Self::new(&data, shape)
+        Self::from_vec(data, shape.to_vec())
     }
 
     /// Get value at index (handles strides)
@@ -207,7 +207,7 @@ impl Tensor {
             .map(|(a, b)| a + b)
             .collect();
 
-        Self::new(&result_data, &self.shape)
+        Self::from_vec(result_data, self.shape.clone())
     }
 
     /// Element-wise multiplication
@@ -225,7 +225,7 @@ impl Tensor {
             .map(|(a, b)| a * b)
             .collect();
 
-        Self::new(&result_data, &self.shape)
+        Self::from_vec(result_data, self.shape.clone())
     }
 
     /// Scalar multiplication
@@ -238,7 +238,7 @@ impl Tensor {
             result_data.push(data[i] * s);
         }
 
-        Self::new(&result_data, &self.shape)
+        Self::from_vec(result_data, self.shape.clone())
     }
 
     /// Transpose (2D)
@@ -282,7 +282,7 @@ impl Tensor {
             .map(|(a, b)| a - b)
             .collect();
 
-        Self::new(&result_data, &self.shape)
+        Self::from_vec(result_data, self.shape.clone())
     }
 
     /// Element-wise mapping
@@ -298,6 +298,6 @@ impl Tensor {
             result_data.push(f(data[i]));
         }
 
-        Self::new(&result_data, &self.shape)
+        Self::from_vec(result_data, self.shape.clone())
     }
 }


### PR DESCRIPTION
💡 **What:** Replaced `Self::new()` with `Self::from_vec()` in `aether-core::ml::tensor` operations (e.g., `add`, `mul`, `zeros`, `ones`, `kaiming_uniform`).
🎯 **Why:** `Self::new()` takes a slice `&[f64]` and internally calls `.to_vec()`, causing a redundant O(N) clone. `Self::from_vec()` takes ownership of an existing `Vec<f64>`, bypassing this unnecessary heap allocation.
📊 **Impact:** Eliminates completely redundant heap allocations in hot-path tensor operations, improving overall performance by avoiding O(N) slice copies during tensor arithmetic and initialization.
🔬 **Measurement:** Verify with `cargo test -p aether-core --offline`. The changes should be 100% behaviorally equivalent.

---
*PR created automatically by Jules for task [14563931828777115187](https://jules.google.com/task/14563931828777115187) started by @teerthsharma*