### PR TITLE
⚡ Bolt: Use iterators for scalar reductions in linalg

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -7,3 +7,6 @@
 ## 2026-07-25 - Tensor metadata cloning in MLP forward passes
 **Learning:** In `aether-core::ml::neural`, cloning the `input` tensor in `MLP::forward` before passing its reference to the first layer's `forward` method triggers an unnecessary heap allocation for tensor metadata and an `Rc` increment.
 **Action:** Extract the first layer using `self.layers.iter_mut()` to pass the initial `input` as a `&Tensor` reference directly, as subsequent layers naturally consume the output of the previous layer.
+## 2026-09-06 - Replacing manual index-based loops with iterators for scalar reductions
+**Learning:** Using high-level operations for scalar reductions in linear algebra creates intermediate allocations. The current fallback is manual loops, but index-based loops perform bounds checking and inhibit vectorization.
+**Action:** Replace manual loops with single-pass iterator chains like `.iter().zip().map().sum()` or `.fold()` across the underlying borrowed arrays to perform scalar reductions.

--- a/crates/aether-core/src/ml/linalg.rs
+++ b/crates/aether-core/src/ml/linalg.rs
@@ -97,29 +97,33 @@ impl LossConfig {
 /// Mean Squared Error
 pub fn mse(y_true: &Tensor, y_pred: &Tensor) -> f64 {
     assert_eq!(y_true.shape, y_pred.shape);
-    let mut sum = 0.0;
     let true_data = y_true.data.borrow();
     let pred_data = y_pred.data.borrow();
     let n = true_data.len();
 
-    for i in 0..n {
-        let diff = true_data[i] - pred_data[i];
-        sum += diff * diff;
-    }
+    let sum: f64 = true_data
+        .iter()
+        .zip(pred_data.iter())
+        .map(|(y, p)| {
+            let diff = y - p;
+            diff * diff
+        })
+        .sum();
     sum / n as f64
 }
 
 /// Mean Absolute Error
 pub fn mae(y_true: &Tensor, y_pred: &Tensor) -> f64 {
     assert_eq!(y_true.shape, y_pred.shape);
-    let mut sum = 0.0;
     let true_data = y_true.data.borrow();
     let pred_data = y_pred.data.borrow();
     let n = true_data.len();
 
-    for i in 0..n {
-        sum += fabs(true_data[i] - pred_data[i]);
-    }
+    let sum: f64 = true_data
+        .iter()
+        .zip(pred_data.iter())
+        .map(|(y, p)| fabs(y - p))
+        .sum();
     sum / n as f64
 }
 
@@ -131,41 +135,47 @@ pub fn rmse(y_true: &Tensor, y_pred: &Tensor) -> f64 {
 /// Binary Cross-Entropy
 pub fn binary_cross_entropy(y_true: &Tensor, y_pred: &Tensor) -> f64 {
     assert_eq!(y_true.shape, y_pred.shape);
-    let mut sum = 0.0;
     let true_data = y_true.data.borrow();
     let pred_data = y_pred.data.borrow();
     let n = true_data.len();
 
-    for i in 0..n {
-        let p = pred_data[i].clamp(1e-7, 1.0 - 1e-7);
-        let y = true_data[i];
-
-        #[cfg(not(feature = "std"))]
-        {
-            sum -= y * log(p) + (1.0 - y) * log(1.0 - p);
-        }
-        #[cfg(feature = "std")]
-        {
-            sum -= y * p.ln() + (1.0 - y) * (1.0 - p).ln();
-        }
-    }
+    let sum: f64 = true_data
+        .iter()
+        .zip(pred_data.iter())
+        .map(|(&y, &p_raw)| {
+            let p = p_raw.clamp(1e-7, 1.0 - 1e-7);
+            #[cfg(not(feature = "std"))]
+            {
+                -(y * log(p) + (1.0 - y) * log(1.0 - p))
+            }
+            #[cfg(feature = "std")]
+            {
+                -(y * p.ln() + (1.0 - y) * (1.0 - p).ln())
+            }
+        })
+        .sum();
     sum / n as f64
 }
 
 /// Hinge Loss (for SVM)
 pub fn hinge_loss(y_true: &Tensor, y_pred: &Tensor) -> f64 {
     assert_eq!(y_true.shape, y_pred.shape);
-    let mut sum = 0.0;
     let true_data = y_true.data.borrow();
     let pred_data = y_pred.data.borrow();
     let n = true_data.len();
 
-    for i in 0..n {
-        let margin = 1.0 - true_data[i] * pred_data[i];
-        if margin > 0.0 {
-            sum += margin;
-        }
-    }
+    let sum: f64 = true_data
+        .iter()
+        .zip(pred_data.iter())
+        .map(|(&y, &p)| {
+            let margin = 1.0 - y * p;
+            if margin > 0.0 {
+                margin
+            } else {
+                0.0
+            }
+        })
+        .sum();
     sum / n as f64
 }
 
@@ -220,57 +230,63 @@ where
 /// Euclidean distance
 pub fn euclidean_distance(a: &Tensor, b: &Tensor) -> f64 {
     assert_eq!(a.shape, b.shape);
-    let mut sum = 0.0;
     let a_data = a.data.borrow();
     let b_data = b.data.borrow();
 
-    for i in 0..a_data.len() {
-        let diff = a_data[i] - b_data[i];
-        sum += diff * diff;
-    }
+    let sum: f64 = a_data
+        .iter()
+        .zip(b_data.iter())
+        .map(|(a_val, b_val)| {
+            let diff = a_val - b_val;
+            diff * diff
+        })
+        .sum();
     sqrt(sum)
 }
 
 /// Manhattan distance (L1)
 pub fn manhattan_distance(a: &Tensor, b: &Tensor) -> f64 {
     assert_eq!(a.shape, b.shape);
-    let mut sum = 0.0;
     let a_data = a.data.borrow();
     let b_data = b.data.borrow();
 
-    for i in 0..a_data.len() {
-        sum += fabs(a_data[i] - b_data[i]);
-    }
-    sum
+    a_data
+        .iter()
+        .zip(b_data.iter())
+        .map(|(a_val, b_val)| fabs(a_val - b_val))
+        .sum()
 }
 
 /// Chebyshev distance (L∞)
 pub fn chebyshev_distance(a: &Tensor, b: &Tensor) -> f64 {
     assert_eq!(a.shape, b.shape);
-    let mut max = 0.0;
     let a_data = a.data.borrow();
     let b_data = b.data.borrow();
 
-    for i in 0..a_data.len() {
-        let abs_val = fabs(a_data[i] - b_data[i]);
-        if abs_val > max {
-            max = abs_val;
-        }
-    }
-    max
+    a_data
+        .iter()
+        .zip(b_data.iter())
+        .map(|(a_val, b_val)| fabs(a_val - b_val))
+        .fold(
+            0.0,
+            |max_val, abs_val| if abs_val > max_val { abs_val } else { max_val },
+        )
 }
 
 /// RBF kernel value
 pub fn rbf_kernel(a: &Tensor, b: &Tensor, gamma: f64) -> f64 {
     assert_eq!(a.shape, b.shape);
-    let mut sum = 0.0;
     let a_data = a.data.borrow();
     let b_data = b.data.borrow();
 
-    for i in 0..a_data.len() {
-        let diff = a_data[i] - b_data[i];
-        sum += diff * diff;
-    }
+    let sum: f64 = a_data
+        .iter()
+        .zip(b_data.iter())
+        .map(|(a_val, b_val)| {
+            let diff = a_val - b_val;
+            diff * diff
+        })
+        .sum();
     exp(-gamma * sum)
 }
 


### PR DESCRIPTION
💡 What: Refactored scalar reductions (mse, mae, cross entropy, distances) to use single pass iterator chains over manual indexed arrays.
      🎯 Why: To skip manual array index checking which creates CPU bound overhead, instead using iterators which allows auto-vectorization.
      📊 Impact: Reduces bounds checking loop cost by $O(N)$ operations.
      🔬 Measurement: Verified by running the core test suite.

---
*PR created automatically by Jules for task [13142602064361315430](https://jules.google.com/task/13142602064361315430) started by @teerthsharma*